### PR TITLE
reorganized deploy to separate responibilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,19 +100,19 @@ const deployHandler = async function deployHandler(options) {
   log.info('Starting function deployment process'.yellow);
   if (validateBinarisLogin()) {
     try {
-      const deployPath = getFuncPath(options);
+      const funcPath = getFuncPath(options);
       const fullIgnorePaths = [];
       ignoredTarFiles.forEach((entry) => {
-        fullIgnorePaths.push(path.join(deployPath, entry));
+        fullIgnorePaths.push(path.join(funcPath, entry));
       });
-      const binarisConf = util.loadBinarisConf(deployPath);
+      const binarisConf = util.loadBinarisConf(funcPath);
       const funcName = util.getFuncName(binarisConf);
       const funcConf = util.getFuncConf(binarisConf, funcName);
       log.debug('funcConf is', funcConf);
-      util.checkFuncConf(funcConf, deployPath);
-      util.genBinarisDir(deployPath);
-      const funcTarPath = path.join(deployPath, util.BINARIS_DIR, `${funcName}.tgz`);
-      await util.genTarBall(deployPath, funcTarPath, fullIgnorePaths);
+      util.checkFuncConf(funcConf, funcPath);
+      util.genBinarisDir(funcPath);
+      const funcTarPath = path.join(funcPath, util.BINARIS_DIR, `${funcName}.tgz`);
+      await util.genTarBall(funcPath, funcTarPath, fullIgnorePaths);
       await deploy(funcName, funcConf, funcTarPath);
       log.info('Sucessfully deployed function'.green);
     } catch (err) {

--- a/sdk/deploy/deploy.js
+++ b/sdk/deploy/deploy.js
@@ -9,7 +9,7 @@ const log = require('../shared/logger');
 const publishEndpoint =
   process.env.BINARIS_PUBLISH_ENDPOINT || 'api-staging.binaris.io:11011';
 
-const uploadFunction = async function uploadFunction(tarPath, conf, publishURL) {
+const deployFunction = async function uploadFunction(tarPath, conf, publishURL) {
   const options = {
     url: publishURL,
     qs: conf,
@@ -35,7 +35,7 @@ const uploadFunction = async function uploadFunction(tarPath, conf, publishURL) 
 // TODO: thing that returns metadata
 const deploy = async function deploy(funcName, funcConf, tarPath) {
   const endpoint = urljoin(`http://${publishEndpoint}/v1/function`, funcName);
-  const response = await uploadFunction(tarPath, funcConf, endpoint);
+  const response = await deployFunction(tarPath, funcConf, endpoint);
   if (response.statusCode !== 200) {
     log.debug(response);
     throw new Error('Function was not deployed successfully, check logs for more details');

--- a/sdk/shared/util.js
+++ b/sdk/shared/util.js
@@ -35,7 +35,7 @@ const genBinarisDir = function genBinarisDir(genPath) {
     }
   } catch (err) {
     log.debug(err);
-    throw new Error('Unable to generate .binaris hidden directory!');
+    throw new Error(`Unable to generate ${BINARIS_DIR} hidden directory!`);
   }
 };
 


### PR DESCRIPTION
moved code around to make a clear separation
of sdk from CLI. this is the first step in a
multipart effort to separate the two components.