### PR TITLE
logging level tip only shown if not set

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -17,7 +17,9 @@ const commander = require('commander');
 const colors = require('colors');
 
 const errorMessageAndExit = function errorMessageAndExit() {
-  log.info('For more information set the BINARIS_LOG_LEVEL environment variable to debug, verbose, info, warn or error');
+  if (!process.env.BINARIS_LOG_LEVEL) {
+    log.info('For more information set the BINARIS_LOG_LEVEL environment variable to debug, verbose, info, warn or error');
+  }
   process.exit(1);
 };
 


### PR DESCRIPTION
the tip regarding setting the env log level
is now only shown if the user has not already
set said logging level.