### PR TITLE
small bug fix for deploy dir gen

### DIFF
--- a/cli-sdk/deploy.js
+++ b/cli-sdk/deploy.js
@@ -19,7 +19,9 @@ const genBinarisDir = async function genBinarisDir(genPath) {
   let fullPath;
   try {
     fullPath = path.join(genPath, binarisDir);
-    await fs.mkdir(fullPath);
+    if (!(await fs.exists(fullPath))) {
+      await fs.mkdir(fullPath);
+    }
   } catch (err) {
     log.debug(err);
     throw new Error(`Error creating working directory: ${binarisDir}`);


### PR DESCRIPTION
deploy couldn't deploy in a dir that had already
been deployed previously.