### PR TITLE
Removal improvements

### DIFF
--- a/cli-sdk/remove.js
+++ b/cli-sdk/remove.js
@@ -2,20 +2,8 @@ const { remove } = require('../sdk');
 const log = require('./logger');
 const YMLUtil = require('./binarisYML');
 
-const removeCLI = async function removeCLI(funcName, funcPath) {
-  if (funcName) {
-    return remove(funcName);
-  }
-
-  let configuredFuncName;
-  try {
-    const binarisConf = await YMLUtil.loadBinarisConf(funcPath);
-    configuredFuncName = YMLUtil.getFuncName(binarisConf);
-  } catch (err) {
-    log.verbose('Failed to read config file', { err, functionName: funcName, path: funcPath });
-    throw new Error(`Failed to read config file for ${funcPath}; specify function name to remove.`);
-  }
-  return remove(configuredFuncName);
+const removeCLI = async function removeCLI(funcName) {
+  return remove(funcName);
 };
 
 module.exports = removeCLI;

--- a/cli.js
+++ b/cli.js
@@ -69,16 +69,10 @@ const deployHandler = async function deployHandler(options) {
 };
 
 // Removes a binaris function that you previously deployed.
-const removeHandler = async function removeHandler(options) {
+const removeHandler = async function removeHandler(functionName) {
   try {
-    const { functionName } = options;
-    const funcPath = getFuncPath(options);
-
-    if (!functionName && !funcPath) {
-      throw new Error('Missing function name. Use --path or --functionName');
-    }
-    log.info(`Removing function: ${functionName || funcPath }...`);
-    await remove(functionName, funcPath);
+    log.info(`Removing function: ${functionName}`);
+    await remove(functionName);
     log.info('Function removed');
   } catch (err) {
     log.error(err.message);
@@ -141,10 +135,8 @@ commander
   .action(deployHandler);
 
 commander
-  .command('remove')
+  .command('remove <functionName>')
   .description('Remove a function from the cloud')
-  .option('-f, --functionName <functionName>', 'name of function to remove')
-  .option('-p, --path <path>', 'path to function')
   .action(removeHandler);
 
 commander


### PR DESCRIPTION
Two separate changes. First simply changes remove to require a functionName and removes the optional path argument. The path wasn't being used correctly anyway and I think for something like Remove the user should be required to supply a name. Furthermore as of now removal doesn't consider the directory or anything since the URL algorithm is simply name + predefined information. We also now print the name of the function on removal. I left the cli-sdk wrapper remove function because once we support multiple functions/auth it will be needed.

The second change is optional and I'm mostly looking for feedback. I know a lot of CLI tools require user confirmation on any sort of destroy/removal. I've implemented the most basic version of this and was wondering what people think. @michaeladda has voiced his strong opinion against and he has very valid criticism. My question mostly to @assaf is whether its considered bad UX. If we like it I will add another patch making it usable(with force command for example)