### PR TITLE
use url-join fully instead of manual concat

### DIFF
--- a/sdk/deploy.js
+++ b/sdk/deploy.js
@@ -31,7 +31,7 @@ const deployFunction = async function uploadFunction(tarPath, conf, deployURL) {
 
 // TODO: thing that returns metadata
 const deploy = async function deploy(funcName, funcConf, tarPath) {
-  const endpoint = urljoin(`https://${deployEndpoint}/v1/function`, funcName);
+  const endpoint = urljoin(`https://${deployEndpoint}`, '/v1/function', funcName);
   const response = await deployFunction(tarPath, funcConf, endpoint);
   if (response.statusCode !== 200) {
     throw new Error(`Error deploying function: ${response.statusCode} ${JSON.parse(response.body).error}`);

--- a/sdk/invoke.js
+++ b/sdk/invoke.js
@@ -3,7 +3,7 @@ const rp = require('request-promise-native');
 const { invokeEndpoint } = require('./config');
 
 const invoke = async function invoke(funcName, funcData) {
-  const endpoint = urljoin(`https://${invokeEndpoint}/v1/user/`, funcName);
+  const endpoint = urljoin(`https://${invokeEndpoint}`, '/v1/user/', funcName);
   const options = {
     url: endpoint,
     body: funcData,

--- a/sdk/remove.js
+++ b/sdk/remove.js
@@ -11,7 +11,7 @@ const removeFunction = async function removeFunction(url) {
 };
 
 const remove = async function remove(funcName) {
-  const endpoint = urljoin(`https://${deployEndpoint}/v1/function`, funcName);
+  const endpoint = urljoin(`https://${deployEndpoint}`, '/v1/function', funcName);
   const response = await removeFunction(endpoint);
   if (response.statusCode === 404) {
     throw new Error(`Function ${funcName} unknown`);


### PR DESCRIPTION
we now url-join to join every part of the URL
(including the hostname). This should allows us
to avoid potential issues with future endpoint
updates.