### PR TITLE
remove first person references from comments

### DIFF
--- a/cli-sdk/binarisYML.js
+++ b/cli-sdk/binarisYML.js
@@ -12,7 +12,7 @@ const funcStr = 'functions';
 const entryStr = 'entrypoint';
 const fileStr = 'file';
 
-// this loads our binaris.yml file from the users current
+// this loads the binaris.yml file from the users current
 // function directory. If it does not exist in the expected
 // location the object returned will have a false 'success'
 // field and a associated error field
@@ -33,7 +33,7 @@ const saveBinarisConf = async function saveBinarisConf(funcDirPath, binarisConf)
   await fs.writeFile(fullYAMLPath, confString, 'utf8');
 };
 
-// this loads our _______.js file from the users current
+// this loads the JS file from the users current
 // function directory. It determines the correct name of the
 // file by inspecting the functions package.json main field.
 // If it does not exist in the expected location the object
@@ -46,7 +46,7 @@ const readFunctionJS = async function readFunctionJS(funcDirPath, JSFileName) {
 };
 
 const getFunctionsSection = function getFunctionsSection(binarisConf) {
-  // ensure our configuration has the field
+  // ensure configuration has the expected field
   if (!Object.prototype.hasOwnProperty.call(binarisConf, funcStr)) {
     throw new Error(`Your ${binarisConfFile} did not contain a require field: <${funcStr}>`);
   }
@@ -80,7 +80,7 @@ const checkFuncConf = async function checkFuncConf(funcConf, funcDirPath) {
 // Assumes a single function.
 const getFuncConf = function getFuncConf(binarisConf, funcName) {
   const funcSection = getFunctionsSection(binarisConf);
-  // ensure our configuration has the correct function
+  // ensure configuration has the correct function
   if (!Object.prototype.hasOwnProperty.call(funcSection, funcName)) {
     throw new Error(`${binarisConfFile}: function missing: ${funcName}`);
   }

--- a/cli-sdk/deploy.js
+++ b/cli-sdk/deploy.js
@@ -13,7 +13,7 @@ const { deploy } = require('../sdk');
 const binarisDir = '.binaris/';
 const ignoredTarFiles = ['.git', '.binaris', 'binaris.yml'];
 
-// creates our hidden .binaris directory in the users function
+// creates hidden .binaris directory in the users function
 // directory if it doesn't already exist
 const genBinarisDir = async function genBinarisDir(genPath) {
   let fullPath;

--- a/cli-sdk/init.js
+++ b/cli-sdk/init.js
@@ -10,8 +10,8 @@ const YMLUtil = require('./binarisYML');
 const templateDir = './functionTemplates/nodejs/';
 
 // TODO: either export this or move it to shared file
-// here we both ensure the name is valid syntatically and eventually
-// we will also determine if it has been previously created
+// currently the code ensures the name is valid syntatically and eventually
+// will also determine if it has been previously created
 const validateFunctionName = function validateFunctionName(name) {
   // eslint issue but too annoying to fix given time
   if (/[~`!#$%^&*+=\\[\]\\';,/{}|\\":<>?]/g.test(name)) {
@@ -48,7 +48,7 @@ const init = async function init(functionName, functionPath) {
   }
 
   log.debug('Loading template files');
-  // parse our templated yml and make the necessary modifications
+  // parse the templated yml and make the necessary modifications
   const templatePath = path.join(__dirname, templateDir);
   const binarisConf = await YMLUtil.loadBinarisConf(templatePath);
   const templateName = YMLUtil.getFuncName(binarisConf);
@@ -66,7 +66,7 @@ const init = async function init(functionName, functionPath) {
   }
   log.debug('Replicating template files');
 
-  // now we have to write out all our files that we've modified
+  // now write out all the files that have been modified
   const file = funcConf.file;
   await fse.copy(path.join(__dirname, templateDir, file), path.join(newDir, file));
   await YMLUtil.saveBinarisConf(newDir, binarisConf);

--- a/cli-sdk/invoke.js
+++ b/cli-sdk/invoke.js
@@ -1,7 +1,7 @@
 const YMLUtil = require('./binarisYML');
 const { invoke } = require('../sdk');
 
-// invokes a binaris function that you have previously
+// invokes a binaris function that has been previously
 // deployed either through the CLI or other means
 const invokeCLI = async function invokeCLI(funcPath, funcName, funcData) {
   const binarisConf = await YMLUtil.loadBinarisConf(funcPath);

--- a/cli.js
+++ b/cli.js
@@ -1,15 +1,14 @@
-// here we just grab all our SDK functions that we plan to use
-// invoke, destroy, help, info, login, logout, signup
+// grab all of the Binaris SDK functions
 const { log, init, invoke, deploy, remove } = require('./cli-sdk');
 
-// grab our version to keep things consistent
+// grab the version to keep things consistent
 const { version } = require('./package.json');
 
-// our core modules
+// core modules
 const fs = require('mz/fs');
 const path = require('path');
 
-// our 3rd party modules
+// 3rd party modules
 const commander = require('commander');
 
 const errorMessageAndExit = function errorMessageAndExit() {
@@ -36,13 +35,12 @@ function getFuncPath(options) {
   return path.resolve(options.path || process.cwd());
 }
 
-// initializes a binaris function based on the options given by
-// the user
+// initializes a binaris function based on the options given by the user
 // this essentially boils down to creating template files with
 // the correct information in the correct location
 const initHandler = async function initHandler(options) {
-  // now we actually call our initialize function and then immediately
-  // determine if was successfully completed
+  // this is where the actual initialize function is called and immediately
+  // evaluated to determine if was successfully completed
   const functionPath = getFuncPath(options);
   try {
     const finalName = await init(options.functionName, functionPath);
@@ -86,7 +84,7 @@ const removeHandler = async function removeHandler(options) {
   }
 };
 
-// invokes a binaris function that you have previously
+// invokes a binaris function that has been previously
 // deployed either through the CLI or other means
 const invokeHandler = async function invokeHandler(functionName, options) {
   if (options.file && options.json) {

--- a/sdk/deploy.js
+++ b/sdk/deploy.js
@@ -9,7 +9,7 @@ const deployFunction = async function uploadFunction(tarPath, conf, deployURL) {
     qs: conf,
   };
   try {
-    // we use raw request here(as opposed to rp) because the
+    // use raw request here(as opposed to rp) because the
     // request-promise module explicitly discourages using
     // request-promise for pipe
     // https://github.com/request/request-promise


### PR DESCRIPTION
this patch removes all usage of "we", and "our"
from the codebase's comments. Before we were using
first person references which may confuse the reader.