### PR TITLE
deploy documentation and cleanup

### DIFF
--- a/cli-sdk/deploy.js
+++ b/cli-sdk/deploy.js
@@ -1,56 +1,53 @@
 const fs = require('mz/fs');
 const path = require('path');
 const { promisify } = require('util');
-
 const { compress } = require('targz');
 
 const tgzCompress = promisify(compress);
 
-const log = require('./logger');
 const { getApiKey } = require('./userConf');
 const { deploy } = require('../sdk');
 
 const binarisDir = '.binaris/';
 const ignoredTarFiles = ['.git', '.binaris', 'binaris.yml'];
 
-// creates hidden .binaris directory in the users function
-// directory if it doesn't already exist
+/**
+ * Generates the .binaris directory inside of the current
+ * functions directory. This directory is used to hold temporary
+ * CLI files related to the function.
+ *
+ * @param {string} genPath - path at which to generate the .binaris dir
+ * @returns {string} - full path to the generated .binaris dir
+ */
 const genBinarisDir = async function genBinarisDir(genPath) {
-  let fullPath;
-  try {
-    fullPath = path.join(genPath, binarisDir);
-    if (!(await fs.exists(fullPath))) {
-      await fs.mkdir(fullPath);
-    }
-  } catch (err) {
-    log.debug(err);
-    throw new Error(`Error creating working directory: ${binarisDir}`);
-  }
+  const fullPath = path.join(genPath, binarisDir);
+  await fs.mkdir(fullPath);
   return fullPath;
 };
 
-const genTarBall = async function genTarBall(dirToTar, dest, ignoredFiles) {
+/**
+ * Deploy a function to the Binaris cloud.
+ *
+ * @param {string} funcName - name of the function to deploy
+ * @param {string} funcPath - path of the function to deploy
+ * @param {object} funcConf - configuration of the function to deploy
+ *
+ * @returns {string} - curlable URL of the endpoint used to invoke your function
+ */
+const deployCLI = async function deployCLI(funcName, funcPath, funcConf) {
+  // path where temporary function tar will be stored
+  const funcTarPath = path.join(await genBinarisDir(funcPath), `${funcName}.tgz`);
+  const fullIgnorePaths = ignoredTarFiles.map(entry =>
+    path.join(funcPath, entry));
   await tgzCompress({
-    src: dirToTar,
-    dest,
+    src: funcPath,
+    dest: funcTarPath,
     tar: {
-      ignore: name => ignoredFiles.includes(name),
+      ignore: name => fullIgnorePaths.includes(name),
     },
   });
-};
-
-// simply handles the process of deploying a function and its
-// associated metadata to the Binaris cloud
-const deployCLI = async function deployCLI(funcName, funcPath, funcConf) {
-  // this should throw an error when it fails
-  const fullIgnorePaths = [];
-  ignoredTarFiles.forEach((entry) => {
-    fullIgnorePaths.push(path.join(funcPath, entry));
-  });
-  const funcTarPath = path.join(await genBinarisDir(funcPath), `${funcName}.tgz`);
-  await genTarBall(funcPath, funcTarPath, fullIgnorePaths);
   const apiKey = await getApiKey();
-  return deploy(apiKey, funcName, funcConf, funcTarPath);
+  return deploy(funcName, apiKey, funcConf, funcTarPath);
 };
 
 module.exports = deployCLI;


### PR DESCRIPTION
Ongoing effort to make sure all function comments are JSDoc. Also just removed unnecessary crud from deploy. Keep in mind these aren't the full fledged comments but rather something
1. correct
2. brief and descriptive
3. JSDoc compatible

Tests: I ran all of the CLI tests on staging