### PR TITLE
remove debug logging except for dialog

### DIFF
--- a/cli-sdk/index.js
+++ b/cli-sdk/index.js
@@ -41,9 +41,6 @@ const exceptionWrapper = function tryCatchWrapper(funcToWrap) {
         log.error(`Permission denied writing to path: ${err.path}`);
       } else {
         log.error(err.message);
-        if (!process.env.BINARIS_LOG_LEVEL) {
-          log.info('For more information set the BINARIS_LOG_LEVEL environment variable to debug, verbose, info, warn or error');
-        }
       }
       return 1;
     }

--- a/cli-sdk/init.js
+++ b/cli-sdk/init.js
@@ -3,7 +3,6 @@ const path = require('path');
 
 const moniker = require('moniker');
 
-const log = require('./logger');
 const YMLUtil = require('./binarisYML');
 
 const templateDir = './functionTemplates/nodejs/';
@@ -30,7 +29,6 @@ const sanitizeName = function sanitizeName(name) {
  */
 const init = async function init(functionName, functionPath) {
   const finalName = sanitizeName(functionName || moniker.choose());
-  log.debug('Loading template files');
   // parse the templated yml and make the necessary modifications
   const templatePath = path.join(__dirname, templateDir);
   const binarisConf = await YMLUtil.loadBinarisConf(templatePath);

--- a/cli-sdk/userConf.js
+++ b/cli-sdk/userConf.js
@@ -2,7 +2,6 @@ const fs = require('mz/fs');
 const { homedir } = require('os');
 const path = require('path');
 const yaml = require('js-yaml');
-const log = require('./logger');
 
 const userConfDirectory = process.env.BINARIS_CONF_DIR || process.env.HOME || homedir();
 const userConfFile = '.binaris.yml';

--- a/test/CLISpec.yml
+++ b/test/CLISpec.yml
@@ -53,12 +53,10 @@
     -   in: bn invoke -p /home/dockeruser/test/alloftheoptions -j myFile.json -d data
         out: |-
             bn: Invoke flags --json(-j) and --data(-d) are mutually exclusive
-            For more information set the BINARIS_LOG_LEVEL environment variable to debug, verbose, info, warn or error
         exit: 1
     -   in: bn invoke -p /home/dockeruser/test/alloftheoptions/ -j myFile.json
         out: |-
             bn: *myFile.json is not a valid path to a JSON file
-            For more information set the BINARIS_LOG_LEVEL environment variable to debug, verbose, info, warn or error
         exit: 1
 
 - test: Unknown command(bad-path)
@@ -103,17 +101,14 @@
     -   in: bn deploy -p /home/dockeruser/test/bogus/comeon/really/hello.js
         out: |-
             bn: No such path: '/home/dockeruser/test/bogus/comeon/really/hello.js'
-            For more information set the BINARIS_LOG_LEVEL environment variable to debug, verbose, info, warn or error
         exit: 1
     -   in: bn invoke -p /home/dockeruser/test/never/will/exist
         out: |-
             bn: No such path: '/home/dockeruser/test/never/will/exist'
-            For more information set the BINARIS_LOG_LEVEL environment variable to debug, verbose, info, warn or error
         exit: 1
     -   in: bn remove -p /home/dockeruser/test/hocus/pocus/fairy
         out: |-
             bn: No such path: '/home/dockeruser/test/hocus/pocus/fairy'
-            For more information set the BINARIS_LOG_LEVEL environment variable to debug, verbose, info, warn or error
         exit: 1
 
 - test: No such directory(bad-path)
@@ -126,12 +121,10 @@
     -   in: bn deploy -p /home/dockeruser/test/someFile.js
         out: |-
             bn: No such directory: '/home/dockeruser/test/someFile.js'
-            For more information set the BINARIS_LOG_LEVEL environment variable to debug, verbose, info, warn or error
         exit: 1
     -   in: bn invoke -p /home/dockeruser/test/abcdefg/anotherFile.txt
         out: |-
             bn: No such directory: '/home/dockeruser/test/abcdefg/anotherFile.txt'
-            For more information set the BINARIS_LOG_LEVEL environment variable to debug, verbose, info, warn or error
         exit: 1
 
 - test: No binaris.yml in directory(bad-path)
@@ -142,7 +135,6 @@
     -   in: bn invoke -p /home/dockeruser/test/trollycopter -f icydiceymolecule
         out: |-
             bn: Cannot find binaris.yml in directory: /home/dockeruser/test/trollycopter
-            For more information set the BINARIS_LOG_LEVEL environment variable to debug, verbose, info, warn or error
         exit: 1
 
 - test: No matching function(bad-path)
@@ -155,5 +147,4 @@
     -   in: bn deploy -p /home/dockeruser/test/grouchybear -f grouchybear
         out: |-
             bn: Cannot find function 'grouchybear' in binaris.yml
-            For more information set the BINARIS_LOG_LEVEL environment variable to debug, verbose, info, warn or error
         exit: 1

--- a/test/test.js
+++ b/test/test.js
@@ -81,21 +81,13 @@ planYAML.forEach((rawSubTest) => {
         // eslint-disable-next-line no-await-in-loop
         await msleep(step.delay);
       }
+
       try {
         // eslint-disable-next-line no-await-in-loop
         const output = await t.context.container.run(`${envs} ${flags}`, step.in, true);
         t.true(globToRegExp(step.out).test(output.slice(0, -1)));
       } catch (err) {
-        // Annoying byproduct of the child_process in node. Because there
-        // are no guarantees regarding ordering, both possible
-        // orderings must be tested to ensure there is a match.
-        const orderOne = `${err.stdout}${err.stderr}`.slice(0, -1);
-        const orderTwo = `${err.stderr}${err.stdout}`.slice(0, -1);
-        if (globToRegExp(step.out).test(orderOne)) {
-          t.true(globToRegExp(step.out).test(orderOne));
-        } else {
-          t.true(globToRegExp(step.out).test(orderTwo));
-        }
+        t.true(globToRegExp(step.out).test(err.stderr.slice(0, -1)));
         t.is(err.code, (step.exit || 0));
       }
     }


### PR DESCRIPTION
In the spec we agreed that the initial incarnation(alpha) will have no debug logs other than what is output to the user directly.  Clearly this in turn means that messages describing how to see more verbose logs aren't very helpful.

Tests: I ran all of the CLI tests on staging