### PR TITLE
Cli arg refinement

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,4 @@ if (!semver.gte(process.version, minNodeVersion)) {
   process.exit(1);
 }
 
-const cli = require('./cli');
-
-// no await/async since this file needs to support lower versions
-Promise.resolve(cli(process.argv)).then((resolve) => {
-  process.exit(resolve);
-});
+require('./cli');


### PR DESCRIPTION
One note for the reviewer. I wasn't sure whether it was better to create a fake wrapper for `unknown option` and remove the existing handler or instead keep the handler and not use the generic exceptionWrapper for unknown option specifically. Because the first option keeps things uniform I went with that route.


Tested both using `npm test` and manually exploring CLI.