### PR TITLE
Return permissions error directly

### DIFF
--- a/cli-sdk/index.js
+++ b/cli-sdk/index.js
@@ -39,11 +39,7 @@ const exceptionWrapper = function tryCatchWrapper(funcToWrap) {
       await funcToWrap(options);
       return 0;
     } catch (err) {
-      if (err.code === 'EACCES') {
-        log.error(`Permission denied writing to path: ${err.path}`);
-      } else {
-        log.error(err.message);
-      }
+      log.error(err.message);
       return 1;
     }
   };

--- a/test/CLISpec.yml
+++ b/test/CLISpec.yml
@@ -123,7 +123,7 @@
   steps:
     -   in: bn init -p /home/dockeruser/test/securedir
         out: |-
-            bn: Permission denied writing to path: /home/dockeruser/test/securedir*
+            bn: EACCES: permission denied, unlink '/home/dockeruser/test/securedir/function.js'
         exit: 1
 
 - test: Superfluous output(bad-path)


### PR DESCRIPTION
We decided that we wouldn't wrap unixy errors ourselves.