### PR TITLE
Changed function.js template to use console

### DIFF
--- a/cli-sdk/functionTemplates/nodejs/function.js
+++ b/cli-sdk/functionTemplates/nodejs/function.js
@@ -1,4 +1,5 @@
 exports.handler = (event, context, callback) => {
   const name = event.queryStringParameters.name || event.body.name || 'World';
+  console.log(`Hello ${name}!`);
   callback(null, { statusCode: 200, body: `Hello ${name}!` });
 };


### PR DESCRIPTION
With logging coming soon, it makes sense to have the template function use `console`