### PR TITLE
Deploy informs users of bad API Key

### DIFF
--- a/sdk/deploy.js
+++ b/sdk/deploy.js
@@ -56,7 +56,7 @@ const deploy = async function deploy(funcName, apiKey, funcConf, tarPath) {
   if (response.statusCode === 404) {
     throw new Error(`Function ${funcName} unknown`);
   } else if (response.statusCode === 405) {
-    throw new Error('Failed to deploy(Invalid API Key)');
+    throw new Error('Failed to deploy (Invalid API Key)');
   } else if (response.statusCode !== 200) {
     throw new Error(`Failed to deploy function ${funcName}`);
   }

--- a/test/CLISpec.yml
+++ b/test/CLISpec.yml
@@ -222,7 +222,7 @@
     -   in: bn create
     -   in: bn deploy
         out: |-
-            Failed to deploy(Invalid API Key)
+            Failed to deploy (Invalid API Key)
         exit: 1
 
 - test: Test invoke(bad-path)


### PR DESCRIPTION
There are overarching changes happening with errors as you know. You just mentioned this as an immediate pain point so I figured the minimum is at least informing about bad API key.