### PR TITLE
login test fix with better log outputs

### DIFF
--- a/test/CLISpec.yml
+++ b/test/CLISpec.yml
@@ -36,6 +36,12 @@
             Created function * in /home/dockeruser
               (use "bn deploy" to deploy the function)
     -   in: echo "$SOME_KEY" | bn login
+        out: |-
+            Please enter your Binaris API key to deploy and invoke functions.
+            If you don't have a key, head over to https://binaris.com to request one
+            *? API Key: 9557231848*
+            *Authentication Succeeded*
+              (use "bn create" to create a template function in your current directory)
     -   in: bn deploy
         out: |-
             Deployed function to *

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,50 @@ const propagatedEnvVars = [
   'BINARIS_LOG_ENDPOINT' ]
 
 /**
+ * Compares a string against it's expected value while
+ * taking into account the star '*' character as catch
+ * all character (including newlines). Starting an expected
+ * string with a '*' and and ending with a '*' are both valid.
+ *
+ * @param {string} expected - expected output from test
+ * @param {string} actual - actual output from test
+ */
+const compareOutput = function compareOutput(t, expected, actual) {
+  // no matter what print out the whole comparison on failure
+  const message = JSON.stringify({ expected, actual }, null, 2);
+  // first split our sections by the star character
+  const expectedSections = expected.split('*');
+  let actualRemaining = actual;
+  for (let i = 0; i < expectedSections.length; i += 1) {
+    const section = expectedSections[i];
+    if (i === 0) {
+      // if the leading character in the string is a star the only
+      // requirement is that the substring exist somewhere in the
+      // actual (regardless of position)
+      if (expected.charAt(0) === '*') {
+        t.true(actualRemaining.indexOf(section) !== -1, message);
+        actualRemaining = actualRemaining.slice(actualRemaining.indexOf(section)
+          + section.length);
+      } else {
+        // ensure the section is the right string in the right place
+        t.is(section, actualRemaining.slice(0, section.length), message);
+        actualRemaining = actualRemaining.slice(section.length);
+      }
+    } else if (i === expectedSections.length - 1) {
+      if (expected.charAt(expected.lastIndexOf() === '*')) {
+        t.true(actualRemaining.indexOf(section) !== -1, message);
+      } else {
+        // just compare the last two parts directly
+        t.is(section, actualRemaining, message);
+      }
+    } else {
+      t.true(actualRemaining.indexOf(section) !== -1, message);
+      actualRemaining = actualRemaining.slice(actualRemaining.indexOf(section));
+    }
+  }
+};
+
+/**
  * Create a Docker container for each test before it runs.
  * This way all test runs are isolated thereby opening up
  * many testing avenues.
@@ -66,9 +110,9 @@ planYAML.forEach((rawSubTest) => {
       // eslint-disable-next-line no-await-in-loop
       const cmdOut = await t.context.ct.streamIn(step.in);
       if (step.out) {
-        t.true(globToRegExp(step.out).test(strip(cmdOut.stdout.slice(0, -1))));
+        compareOutput(t, step.out, strip(cmdOut.stdout.slice(0, -1)));
       } else if (step.err) {
-        t.true(globToRegExp(step.err).test(strip(cmdOut.stderr.slice(0, -1))));
+        compareOutput(t, step.err, strip(cmdOut.stderr.slice(0, -1)));
       }
       t.is(cmdOut.exitCode, (step.exit || 0));
     }


### PR DESCRIPTION
Ok so this PR is going to probably have some serious discussion. The main goal here is to get the login test to pass with all the crap currently being spewed out of inquirer. The previous solution `globToRegExp` doesn't allow us to match new lines with `*` .  The code in the patch seems a bit clunky but it has a pretty nice side effect. It produces incredibly accurate error outputs when your expected doesn't meet its actual value. 

If the reviewers deem the code is too clunky we can explore some alternatives. One option is to manually replace * with `[.\s\S]*` and then convert the individual output pieces to a Regexp and merge them using a technique such as the ones described here https://stackoverflow.com/questions/9213237/combining-regular-expressions-in-javascript.

This is an example of what a failed `Test login` would look like. 

```
  1 test failed

  Test login(good-path)

  /home/ubuntu/binaris/test/test.js:57

   56:     } else {
   57:       t.true(actualRemaining.indexOf(section) !== -1, message);
   58:       actualRemaining = actualRemaining.slice(actualRemaining.indexOf(section));

  {
    "expected": "Please enter your Binaris API key to deploy and invoke functions.\nIf you don't have a key, head over to https://binaris.com to request one\n*? API Key: 955sdjna231848*\n*Authentication Succeeded*\n  (use \"bn create\" to create a template function in your current directory)",
    "actual": "Please enter your Binaris API key to deploy and invoke functions.\nIf you don't have a key, head over to https://binaris.com to request one\n,? API Key: ,,,? API Key: 9,? API Key: 95? API Key: 955? API Key: 9557? API Key: 95572? API Key: 955723? API Key: 9557231? API Key: 95572318? API Key: 955723184? API Key: 9557231848,? API Key: 9557231848\n,Authentication Succeeded\n  (use \"bn create\" to create a template function in your current directory)"
  }

  Value is not `true`:

  false

  actualRemaining.indexOf(section)!==-1
  => false

  -1
  => -1

  actualRemaining.indexOf(section)
  => -1

  section
  => '? API Key: 955sdjna231848'

  actualRemaining
  => `,? API Key: ,,,? API Key: 9,? API Key: 95? API Key: 955? API Key: 9557? API Key: 95572? API Key: 955723? API Key: 9557231? API Key: 95572318? API Key: 955723184? API Key: 9557231848,? API Key: 9557231848␊
  ,Authentication Succeeded␊
    (use "bn create" to create a template function in your current directory)`

  compareOutput (test/test.js:57:7)
  Test.test [as fn] (test/test.js:113:9)



  The .only() modifier is used in some tests. 18 tests were not run
```