### PR TITLE
use correct realm in first jenkins run of a branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,9 @@ node {
             ]),
     ]);
     try {
+        def realm = params.realm;
+        if (!realm) { error('realm not defined'); }
+
         ansiColor('xterm') {
             stage('Build') {
                 echo 'Building docker image';
@@ -35,13 +38,13 @@ node {
                     job: "/realms/deploy",
                     wait: true,
                     parameters: [
-                    string(name: 'realm', value:realm),
-                    string(name: 'tag', value:"master")
+                    string(name: 'realm', value: "${realm}"),
+                    string(name: 'tag', value: "master")
                     ]
                 )
             }
             stage('Generate key') {
-               lock("${params.realm}-realm") {
+               lock("${realm}-realm") {
                    echo 'Generating API key'
                    sh """
                       REGION=`curl -Ls https://ubkw9cm2nh.execute-api.us-east-1.amazonaws.com/dev/fetch/${realm} | jq -r .region`
@@ -51,7 +54,7 @@ node {
                }
             }
             stage('Test') {
-                lock("${params.realm}-realm") {
+                lock("${realm}-realm") {
                     timeout(time: 5, unit: 'MINUTES') {
                       echo 'Running CLI tests'
                       sh """


### PR DESCRIPTION
realm env var on jenkins is ops, and during the first run of a branch the params do not pass to the env var, therefore everything depending on them should be well defined.
tested by running jenkins with and without this commit, and gladly observing without it ops is not demolished due to `18:01:29 Important realm protection activated.` while without it works with the correct default realm (`staging`)