### PR TITLE
print color only in interactive shell

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -15,10 +15,11 @@ winston.addColors(colorLevels);
 
 const formatter = function formatter(options) {
   const body = options.message ? options.message : '';
-  const sufix = (options.meta && Object.keys(options.meta).length
+  const suffix = (options.meta && Object.keys(options.meta).length
    ? `\n\t${JSON.stringify(options.meta)}` : '');
 
-  return config.colorize(options.level, `${body}${sufix}`);
+  const fullLog = `${body}${suffix}`;
+  return process.stdout.isTTY ? config.colorize(options.level, fullLog) : fullLog;
 };
 
 winston.loggers.add('binaris', {
@@ -27,7 +28,7 @@ winston.loggers.add('binaris', {
       stringify: true,
       level: process.env.BINARIS_LOG_LEVEL || 'info',
       prettyPrint: true,
-      colorize: true,
+      colorize: process.stdout.isTTY,
       // eslint-disable-next-line arrow-body-style
       formatter,
     }),


### PR DESCRIPTION
I'm not sure why it's necessary to both disable the colors(in the config.colorize part) and the flag. I figured it wasn't worth it to put effort into researching/fixing so I kept as is.

Tested with CLI tests and by manually using `bn invoke | less` as an example