### PR TITLE
Detect if colors are supported, not just TTY

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,4 +1,5 @@
 const winston = require('winston');
+const supportsColor = require('supports-color');
 
 const config = winston.config;
 
@@ -19,7 +20,7 @@ const formatter = function formatter(options) {
    ? `\n\t${JSON.stringify(options.meta)}` : '');
 
   const fullLog = `${body}${suffix}`;
-  return process.stdout.isTTY ? config.colorize(options.level, fullLog) : fullLog;
+  return supportsColor.stdout ? config.colorize(options.level, fullLog) : fullLog;
 };
 
 winston.loggers.add('binaris', {
@@ -28,7 +29,7 @@ winston.loggers.add('binaris', {
       stringify: true,
       level: process.env.BINARIS_LOG_LEVEL || 'info',
       prettyPrint: true,
-      colorize: process.stdout.isTTY,
+      colorize: supportsColor.stdout,
       // eslint-disable-next-line arrow-body-style
       formatter,
     }),

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "request-promise-native": "^1.0.5",
     "semver": "^5.4.1",
     "string-argv": "0.0.2",
+    "supports-color": "^5.4.0",
     "targz": "^1.0.1",
     "urljoin": "^0.1.5",
     "uuid": "^3.1.0",


### PR DESCRIPTION
Tested by manually causing errors and verifying colors work. Then using CLI spec and ensuring non-TTY tests pass.