### PR TITLE
Bump CLI version for new `latest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binaris",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Binaris SDK & CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
We have a beta version of the CLI dependent on not yet functioning backend support. Realistically we should have bumped more from recent patches. The alternative to this PR is to `unpublish` and `republish` under the current master version `3.0.1` with the correct `latest` tag.