### PR TITLE
use default (cpu cores) concurrency in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "source": [
       "**/*.{js,jsx}"
     ],
-    "concurrency": 5,
     "verbose": true
   }
 }


### PR DESCRIPTION
tested by jenkins