### PR TITLE
Add logic to handle bad spec tests

### DIFF
--- a/test/cases.yml
+++ b/test/cases.yml
@@ -1,4 +1,9 @@
 ---
+- test: Bad spec item (bad-path)
+  steps:
+    -   in: exit 1
+        exit: 1
+
 - test: No binaris.yml in directory (bad-path)
   setup:
     - mkdir -p /home/dockeruser/test/trollycopter

--- a/test/helpers/container.js
+++ b/test/helpers/container.js
@@ -92,6 +92,13 @@ class Container {
       stdout: true,
       stderr: true,
     });
+
+    // handle the case of the bash process itself crashing
+    this.dockerStream.on('end', () => {
+      this.cmdUUID = undefined;
+      this.exitCode = 1;
+      this.started = false;
+    });
     // separates out stderr/stdout, this can also be done manually with the headers
     this.container.modem.demuxStream(this.dockerStream, this.outStream, this.errStream);
     // start the container and wait for the startup command to finish
@@ -157,6 +164,7 @@ class Container {
     if (this.container && this.started) {
       await this.container.stop();
       await this.container.remove();
+      this.started = false;
     }
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -37,18 +37,20 @@ test.beforeEach(async (t) => {
  * Always call `remove` on the container before exit
  */
 test.afterEach.always(async (t) => {
-  if (t.context.cleanup) {
-    for (const cleanupStep of t.context.cleanup) {
-      // eslint-disable-next-line no-await-in-loop
-      const result = await t.context.ct.streamIn(`${commonBashOpts} ${cleanupStep}`);
-      if (result.exitCode !== 0) {
-        t.log(`Cleanup stdout: ${result.stdout}`);
-        t.log(`Cleanup stderr: ${result.stderr}`);
-        throw new Error(result.stderr);
+  if (t.context.ct.started) {
+    if (t.context.cleanup) {
+      for (const cleanupStep of t.context.cleanup) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await t.context.ct.streamIn(`${commonBashOpts} ${cleanupStep}`);
+        if (result.exitCode !== 0) {
+          t.log(`Cleanup stdout: ${result.stdout}`);
+          t.log(`Cleanup stderr: ${result.stderr}`);
+          throw new Error(result.stderr);
+        }
       }
     }
+    await t.context.ct.stopAndKillContainer();
   }
-  await t.context.ct.stopAndKillContainer();
 });
 
 /**


### PR DESCRIPTION
This is a simple/initial fix to the case where anything causes our container to crash. In the future we should also handle the issue of re-creating a container to do any unfinished cleanup.

Tested this manually.