### PR TITLE
Don't show API_KEY during login

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -227,7 +227,7 @@ const loginHandler = async function loginHandler() {
 `Please enter your Binaris API key to deploy and invoke functions.
 If you don't have a key, head over to https://binaris.com to request one`);
   const answer = await inquirer.prompt([{
-    type: 'input',
+    type: 'password',
     name: 'apiKey',
     message: 'API Key:',
   }]);


### PR DESCRIPTION
@lavie this is something you brought up so I wanted to tell you why the solution is not optimal. It's not simple to only mask a portion of the text segment (ie: *********KEY) using `inquirer.js`. Allegedly there is a field called `transformer` that should allow a custom function to modify the incremental input but it simply does not work when I define it. I figured this is the best immediate solution.