### PR TITLE
Fix part of hanging container issue

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -46,6 +46,8 @@ test.afterEach.always(async (t) => {
         if (result.exitCode !== 0) {
           t.log(`Cleanup stdout: ${result.stdout}`);
           t.log(`Cleanup stderr: ${result.stderr}`);
+          // eslint-disable-next-line no-await-in-loop
+          await t.context.ct.stopAndKillContainer();
           throw new Error(result.stderr);
         }
       }


### PR DESCRIPTION
There are definitely some underlying inconsistencies in our container cleanup process but this fix at least handles part of it. Previously, if the cleanup failed we didn't handle removing the container at all. Unfortunately I still am seeing hanging Jenkins containers on some tests that have no cleanup phase.