### PR TITLE
Increase concurrency.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -64,7 +64,7 @@ const testFileNames = ['./test/spec.yml', './test/cases.yml'];
 const testFiles = testFileNames.map(file => yaml.safeLoad(fs.readFileSync(file, 'utf8')));
 const testPlan = [].concat(...testFiles);
 
-const limiter = throat(4);
+const limiter = throat(10);
 
 function limitedTest(name, testFn) {
   return test(name, async t => limiter(async () => testFn(t)));


### PR DESCRIPTION
System should be (much) better protected against concurrent deploys.
Start exercising it.  Note that during full-system tests 2 other repos
_also_ deploy functions, concurrently, and this is unprotected by
throttling in this repo.