### PR TITLE
Add optional data param to perf

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -135,6 +135,11 @@ Usage: $0 <command> [options]` // eslint-disable-line comma-dangle
         type: 'number',
         default: 1,
       })
+      .option('data', {
+        alias: 'd',
+        describe: 'Data to include with performance invocations',
+        type: 'string',
+      })
       .example(
 ` // Run performance test on function foo (100 invocations, serially)
   bn perf foo
@@ -144,6 +149,9 @@ Usage: $0 <command> [options]` // eslint-disable-line comma-dangle
 
   // Run performance test with 1,000 invocations and 4 concurrent connections
   bn perf foo -n 1000 -c 4
+
+  // Run performance test with 1,000 invocations and send JSON data with each request
+  bn perf foo -n 1000 -d '{ "someData": "myData" }'
 `);
   }, async (argv) => {
     await handleCommand(argv, perfHandler);

--- a/lib/index.js
+++ b/lib/index.js
@@ -146,7 +146,8 @@ const perfHandler = async function perfHandler(options) {
 Executing ${options.maxRequests} invocations with ${options.concurrency} "thread${options.concurrency > 1 ? 's' : ''}".
 Stand by for results...
 `);
-  const report = await perf(options.function, options.maxRequests, options.concurrency);
+  const report = await perf(options.function, options.maxRequests,
+    options.concurrency, options.data);
   logger.info('Perf summary');
   logger.info('============');
 

--- a/lib/perf.js
+++ b/lib/perf.js
@@ -10,9 +10,9 @@ const { perf } = require('../sdk');
  *
  * @returns {object} - latency report (based on the loadtest npm package)
  */
-const perfCLI = async function perfCLI(funcName, maxRequests, concurrency) {
+const perfCLI = async function perfCLI(funcName, maxRequests, concurrency, funcData) {
   const apiKey = await getAPIKey();
-  return perf(apiKey, funcName, maxRequests, concurrency);
+  return perf(apiKey, funcName, maxRequests, concurrency, funcData);
 };
 
 module.exports = perfCLI;

--- a/sdk/perf.js
+++ b/sdk/perf.js
@@ -14,10 +14,11 @@ const logger = require('../lib/logger');
  *
  * @returns {object} - latency report (based on the loadtest npm package)
  */
-const perf = async function perf(apiKey, funcName, maxRequests, concurrency) {
+const perf = async function perf(apiKey, funcName, maxRequests, concurrency, funcData) {
   const options = {
     url: urljoin(`https://${getInvokeEndpoint()}`, 'v1', 'run', apiKey, funcName),
     headers: { 'Content-Type': 'application/json' },
+    body: funcData,
     // body: TODO: add optional json body
     concurrency,
     maxRequests,


### PR DESCRIPTION
Tested manually by adding `console.log` to the function and ensuring body gets logged.