### PR TITLE
Add 'use strict'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,8 @@ module.exports = {
     "no-unused-vars": ["error", {
       argsIgnorePattern: "^unused",
     }],
+  },
+  "parserOptions": {
+    "sourceType": "script"
   }
-
 };

--- a/cli.js
+++ b/cli.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const yargs = require('yargs');
 
 const logger = require('./lib/logger');

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+'use strict';
+
 const minNodeVersion = '8.0.0';
 const semver = require('semver');
 

--- a/lib/binarisYML.js
+++ b/lib/binarisYML.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // this is just a convenience/wrapper for the individual commands
 const fs = require('mz/fs');
 

--- a/lib/create.js
+++ b/lib/create.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fse = require('fs-extra');
 const path = require('path');
 

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fse = require('fs-extra');
 const path = require('path');
 const urljoin = require('urljoin');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const deploy = require('./deploy');
 const create = require('./create');
 const invoke = require('./invoke');

--- a/lib/invoke.js
+++ b/lib/invoke.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { getAPIKey } = require('./userConf');
 const { invoke } = require('../sdk');
 

--- a/lib/list.js
+++ b/lib/list.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { getAPIKey } = require('./userConf');
 const { list } = require('../sdk');
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const winston = require('winston');
 const supportsColor = require('supports-color');
 

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { logs } = require('../sdk');
 const { getAPIKey } = require('./userConf');
 

--- a/lib/nameUtil.js
+++ b/lib/nameUtil.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // allows only letters and numbers
 const validNameRegex = /[^A-Za-z0-9]/g;
 

--- a/lib/perf.js
+++ b/lib/perf.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { getAPIKey } = require('./userConf');
 const { perf } = require('../sdk');
 

--- a/lib/remove.js
+++ b/lib/remove.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { remove } = require('../sdk');
 const { getAPIKey } = require('./userConf');
 

--- a/lib/runtimes.js
+++ b/lib/runtimes.js
@@ -1,1 +1,3 @@
+'use strict';
+
 module.exports = ['node8', 'python2', 'pypy2', 'java8', 'python3'];

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { stats } = require('../sdk');
 const { getAPIKey } = require('./userConf');
 

--- a/lib/timeUtil.js
+++ b/lib/timeUtil.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /* eslint-disable radix */
 const moment = require('moment');
 

--- a/lib/userConf.js
+++ b/lib/userConf.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('mz/fs');
 const { homedir } = require('os');
 const path = require('path');

--- a/sdk/auth.js
+++ b/sdk/auth.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const urljoin = require('urljoin');
 const rp = require('request-promise-native');
 

--- a/sdk/config.js
+++ b/sdk/config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const getDeployEndpoint = function getDeployEndpoint() {
   return process.env.BINARIS_DEPLOY_ENDPOINT || 'api.binaris.com';
 };

--- a/sdk/deploy.js
+++ b/sdk/deploy.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 const urljoin = require('urljoin');
 const request = require('request');

--- a/sdk/handleError.js
+++ b/sdk/handleError.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const get = require('lodash.get');
 const { inspect } = require('util');
 const rp = require('request-promise-native');

--- a/sdk/index.js
+++ b/sdk/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // this is just a convenience/wrapper for the individual commands
 const auth = require('./auth');
 const deploy = require('./deploy');

--- a/sdk/invoke.js
+++ b/sdk/invoke.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const urljoin = require('urljoin');
 const rp = require('request-promise-native');
 

--- a/sdk/list.js
+++ b/sdk/list.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const urljoin = require('urljoin');
 
 const { getDeployEndpoint } = require('./config');

--- a/sdk/logs.js
+++ b/sdk/logs.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const urljoin = require('urljoin');
 const { loggedRequest, validateResponse } = require('./handleError');
 const logger = require('../lib/logger');

--- a/sdk/perf.js
+++ b/sdk/perf.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const urljoin = require('urljoin');
 const { loadTest } = require('loadtest');
 

--- a/sdk/remove.js
+++ b/sdk/remove.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const urljoin = require('urljoin');
 
 const { getDeployEndpoint } = require('./config');

--- a/sdk/stats.js
+++ b/sdk/stats.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const urljoin = require('urljoin');
 const logger = require('../lib/logger');
 const { getValidatedBody } = require('./handleError');

--- a/sdk/test/deployTest.js
+++ b/sdk/test/deployTest.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // SDK dir structure confuses eslint
 /* eslint-disable import/no-extraneous-dependencies */
 const test = require('ava');

--- a/test/helpers/container.js
+++ b/test/helpers/container.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Docker = require('dockerode');
 
 const docker = new Docker();

--- a/test/helpers/msleep.js
+++ b/test/helpers/msleep.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Imitates stdc sleep behavior using es6 async/await
  *

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // Test runner
 const test = require('ava');
 


### PR DESCRIPTION
Tested that the scripts were not in strict mode by writing code that would fail in strict mode and running it successfully, specifically:

```javascript
(14).sailing = 'home';
```

Even though most of strict mode help is also caught by the linter, it makes sense to have the additional checks.