### PR TITLE
Use V2 URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ DOCKER_IMAGE := binaris/binaris
 version := $(shell cat package.json | jq -r ".version")
 
 define cli_envs
+	-e BINARIS_TEMPORARY_API_KEY_FOR_TESTING_OLD_ENDPOINTS       \
 	-e BINARIS_LOG_LEVEL       \
 	-e tag                     \
 	-e BINARIS_API_KEY         \

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ define cli_envs
 	-e BINARIS_LOG_LEVEL       \
 	-e tag                     \
 	-e BINARIS_API_KEY         \
+	-e BINARIS_ACCOUNT_ID      \
 	-e BINARIS_INVOKE_ENDPOINT \
 	-e BINARIS_DEPLOY_ENDPOINT \
 	-e BINARIS_LOG_ENDPOINT

--- a/cli.js
+++ b/cli.js
@@ -270,7 +270,7 @@ Usage: $0 <command> [options]` // eslint-disable-line comma-dangle
     }
     await handleCommand(argv, statsHandler);
   })
-  .command('login', 'Login to your Binaris account using an API key', (yargs0) => {
+  .command('login', 'Login to your Binaris account using an API key and account id', (yargs0) => {
     yargs0
       .usage('Usage: $0 login')
       .strict();

--- a/cli.js
+++ b/cli.js
@@ -3,12 +3,14 @@
 const yargs = require('yargs');
 
 const logger = require('./lib/logger');
+const { getRealm } = require('./lib/userConf');
 const { parseTimeString } = require('./lib/timeUtil');
 const {
   deployHandler, createHandler, invokeHandler, listHandler,
   logsHandler, loginHandler, removeHandler, perfHandler,
   statsHandler,
 } = require('./lib');
+const { forceRealm } = require('./sdk');
 
 /**
  * Prints the provided message(along with optionally displayed help)
@@ -24,6 +26,10 @@ const msgAndExit = function msgAndExit(message, displayHelp) {
 };
 
 const handleCommand = async function handleCommand(options, specificHandler) {
+  const realm = await getRealm();
+  if (realm) {
+    forceRealm(realm);
+  }
   const cmdSeq = options._;
   // `_` is the array holding all commands given to yargs
   if (cmdSeq.length > 1) {

--- a/cli.js
+++ b/cli.js
@@ -230,7 +230,7 @@ Usage: $0 <command> [options]` // eslint-disable-line comma-dangle
     }
     await handleCommand(argv, logsHandler);
   })
-  .command('stats [options]', 'Print usage statistics', (yargs0) => {
+  .command('stats [options]', /* hidden: 'Print usage statistics' */ false, (yargs0) => {
     yargs0
       .usage('Usage: $0 stats [options]')
       .option('since', {

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -2,15 +2,14 @@
 
 const fse = require('fs-extra');
 const path = require('path');
-const urljoin = require('urljoin');
 const { promisify } = require('util');
 const { compress } = require('targz');
 
 const tgzCompress = promisify(compress);
 
-const { getAPIKey } = require('./userConf');
+const { getAccountId, getAPIKey } = require('./userConf');
 const { deploy } = require('../sdk');
-const { getInvokeEndpoint } = require('../sdk/config');
+const { getInvokeUrl } = require('../sdk/url');
 
 const binarisDir = '.binaris/';
 const ignoredTarFiles = ['.git', '.binaris', 'binaris.yml'];
@@ -51,8 +50,9 @@ const deployCLI = async function deployCLI(funcName, funcPath, funcConf) {
     },
   });
   const apiKey = await getAPIKey();
-  await deploy(funcName, apiKey, funcConf, funcTarPath);
-  return urljoin(`https://${getInvokeEndpoint()}`, 'v1', 'run', apiKey, funcName);
+  const accountId = await getAccountId(undefined);
+  await deploy(accountId, funcName, apiKey, funcConf, funcTarPath);
+  return getInvokeUrl(accountId, funcName, apiKey);
 };
 
 module.exports = deployCLI;

--- a/lib/index.js
+++ b/lib/index.js
@@ -261,22 +261,18 @@ const statsHandler = async function statsHandler(options) {
  */
 const loginHandler = async function loginHandler() {
   logger.info(
-`Please enter your Binaris account ID and API key to deploy and invoke functions.
-If you don't have an account ID or key, head over to https://binaris.com to request one`);
-  const { accountId, apiKey } = await inquirer.prompt([
-    {
-      type: 'text',
-      name: 'accountId',
-      message: 'Account ID:',
-    },
+`Please enter your Binaris API key to deploy and invoke functions.
+If you don't have a key, head over to https://binaris.com to request one`);
+  const { apiKey } = await inquirer.prompt([
     {
       type: 'password',
       name: 'apiKey',
       message: 'API Key:',
     },
   ]);
-  if (!await auth.verifyAPIKey(accountId, apiKey)) {
-    throw new Error('Invalid API key');
+  const { accountId, error } = await auth.verifyAPIKey(apiKey);
+  if (error) {
+    throw error;
   }
   await updateAccountId(accountId);
   await updateAPIKey(apiKey);

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ const logger = require('./logger');
 const perf = require('./perf');
 const remove = require('./remove');
 const YMLUtil = require('./binarisYML');
-const { updateAPIKey } = require('./userConf');
+const { getAPIKey, updateAccountId, updateAPIKey } = require('./userConf');
 const { auth } = require('../sdk');
 const { validateName } = require('./nameUtil');
 const sortBy = require('lodash.sortby');
@@ -101,10 +101,14 @@ const createHandler = async function createHandler(options) {
  */
 const deployHandler = async function deployHandler(options) {
   const meta = await gatherMeta(options);
+  const apiKey = await getAPIKey();
   const endpoint = await deploy(meta.name, meta.path, meta.conf);
+
   logger.info(
-`Deployed function to ${endpoint}
-  (use "bn invoke${meta.printPath}${meta.printName}" to invoke the function)`);
+`Deployed function ${meta.name}
+ Invoke with one of:
+   "bn invoke${meta.printPath}${meta.printName}"
+   "curl -H X-Binaris-Api-Key:${apiKey} ${endpoint}"`);
 };
 
 /**
@@ -257,17 +261,25 @@ const statsHandler = async function statsHandler(options) {
  */
 const loginHandler = async function loginHandler() {
   logger.info(
-`Please enter your Binaris API key to deploy and invoke functions.
-If you don't have a key, head over to https://binaris.com to request one`);
-  const answer = await inquirer.prompt([{
-    type: 'password',
-    name: 'apiKey',
-    message: 'API Key:',
-  }]);
-  if (!await auth.verifyAPIKey(answer.apiKey)) {
+`Please enter your Binaris account ID and API key to deploy and invoke functions.
+If you don't have an account ID or key, head over to https://binaris.com to request one`);
+  const { accountId, apiKey } = await inquirer.prompt([
+    {
+      type: 'text',
+      name: 'accountId',
+      message: 'Account ID:',
+    },
+    {
+      type: 'password',
+      name: 'apiKey',
+      message: 'API Key:',
+    },
+  ]);
+  if (!await auth.verifyAPIKey(accountId, apiKey)) {
     throw new Error('Invalid API key');
   }
-  await updateAPIKey(answer.apiKey);
+  await updateAccountId(accountId);
+  await updateAPIKey(apiKey);
   logger.info(
 `Authentication Succeeded
   (use "bn create node8 hello" to create a Node.js template function in your CWD)`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,9 +106,9 @@ const deployHandler = async function deployHandler(options) {
 
   logger.info(
 `Deployed function ${meta.name}
- Invoke with one of:
-   "bn invoke${meta.printPath}${meta.printName}"
-   "curl -H X-Binaris-Api-Key:${apiKey} ${endpoint}"`);
+Invoke with one of:
+  "bn invoke${meta.printPath}${meta.printName}"
+  "curl -H X-Binaris-Api-Key:${apiKey} ${endpoint}"`);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,8 +10,8 @@ const logger = require('./logger');
 const perf = require('./perf');
 const remove = require('./remove');
 const YMLUtil = require('./binarisYML');
-const { getAPIKey, updateAccountId, updateAPIKey } = require('./userConf');
-const { auth } = require('../sdk');
+const { getAPIKey, updateAccountId, updateAPIKey, updateRealm } = require('./userConf');
+const { auth, forceRealm } = require('../sdk');
 const { validateName } = require('./nameUtil');
 const sortBy = require('lodash.sortby');
 
@@ -263,19 +263,30 @@ const loginHandler = async function loginHandler() {
   logger.info(
 `Please enter your Binaris API key to deploy and invoke functions.
 If you don't have a key, head over to https://binaris.com to request one`);
-  const { apiKey } = await inquirer.prompt([
+  const { rawApiKey } = await inquirer.prompt([
     {
       type: 'password',
-      name: 'apiKey',
+      name: 'rawApiKey',
       message: 'API Key:',
     },
   ]);
+
+  const apiKeyIdx = rawApiKey.lastIndexOf('-');
+  const apiKey = rawApiKey.substr(apiKeyIdx + 1);
+  const realm = rawApiKey.substr(0, apiKeyIdx);
+
+  if (realm) {
+    forceRealm(realm);
+  }
   const { accountId, error } = await auth.verifyAPIKey(apiKey);
   if (error) {
     throw error;
   }
+
   await updateAccountId(accountId);
   await updateAPIKey(apiKey);
+  await updateRealm(realm);
+
   logger.info(
 `Authentication Succeeded
   (use "bn create node8 hello" to create a Node.js template function in your CWD)`);

--- a/lib/invoke.js
+++ b/lib/invoke.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { getAPIKey } = require('./userConf');
+const { getAccountId, getAPIKey } = require('./userConf');
 const { invoke } = require('../sdk');
 
 /**
@@ -14,7 +14,8 @@ const { invoke } = require('../sdk');
  */
 const invokeCLI = async function invokeCLI(funcName, funcData) {
   const apiKey = await getAPIKey();
-  return invoke(funcName, apiKey, funcData);
+  const accountId = await getAccountId(undefined);
+  return invoke(accountId, funcName, apiKey, funcData);
 };
 
 module.exports = invokeCLI;

--- a/lib/list.js
+++ b/lib/list.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { getAPIKey } = require('./userConf');
+const { getAccountId, getAPIKey } = require('./userConf');
 const { list } = require('../sdk');
 
 /**
@@ -21,7 +21,8 @@ const { list } = require('../sdk');
  */
 const listCLI = async function listCLI() {
   const apiKey = await getAPIKey();
-  return list(apiKey);
+  const accountId = await getAccountId(undefined);
+  return list(accountId, apiKey);
 };
 
 module.exports = listCLI;

--- a/lib/logs.js
+++ b/lib/logs.js
@@ -1,18 +1,19 @@
 'use strict';
 
 const { logs } = require('../sdk');
-const { getAPIKey } = require('./userConf');
+const { getAccountId, getAPIKey } = require('./userConf');
 
 /**
  * Retrieves the logs of a previously deployed Binaris function.
  *
- * @param {string} functionName - name of functions whose logs will be retrieved
+ * @param {string} funcName - name of functions whose logs will be retrieved
  * @param {boolean} follow - read the logs in tail -f fashion
  * @param {moment} since - get log since date
  * @param {ReadableStream} logStream - output stream to feed log records
  */
 const logCLI = async function logCLI(funcName, follow, since, logStream) {
   const apiKey = await getAPIKey();
+  const accountId = await getAccountId(undefined);
   let token;
   let startAfter = since && since.toISOString();
   if (!follow && !startAfter) {
@@ -22,7 +23,7 @@ const logCLI = async function logCLI(funcName, follow, since, logStream) {
   }
   do {
     // eslint-disable-next-line no-await-in-loop
-    const { nextToken, body } = await logs(funcName, apiKey, follow, startAfter, token);
+    const { nextToken, body } = await logs(accountId, funcName, apiKey, follow, startAfter, token);
     for (const record of body) {
       logStream.push(record);
     }

--- a/lib/nameUtil.js
+++ b/lib/nameUtil.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // allows only letters and numbers
-const validNameRegex = /[^A-Za-z0-9]/g;
+const validNameRegex = /[^A-Za-z0-9_]/g;
 
 /**
  * Verifies whether the provided function name meets

--- a/lib/perf.js
+++ b/lib/perf.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { getAPIKey } = require('./userConf');
+const { getAccountId, getAPIKey } = require('./userConf');
 const { perf } = require('../sdk');
 
 /**
@@ -13,8 +13,9 @@ const { perf } = require('../sdk');
  * @returns {object} - latency report (based on the loadtest npm package)
  */
 const perfCLI = async function perfCLI(funcName, maxRequests, concurrency, funcData, maxSeconds) {
+  const accountId = await getAccountId(undefined);
   const apiKey = await getAPIKey();
-  return perf(apiKey, funcName, maxRequests, concurrency, funcData, maxSeconds);
+  return perf(accountId, funcName, apiKey, maxRequests, concurrency, funcData, maxSeconds);
 };
 
 module.exports = perfCLI;

--- a/lib/remove.js
+++ b/lib/remove.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { remove } = require('../sdk');
-const { getAPIKey } = require('./userConf');
+const { getAccountId, getAPIKey } = require('./userConf');
 
 /**
  * Removes the function from the Binaris cloud.
@@ -10,7 +10,8 @@ const { getAPIKey } = require('./userConf');
  */
 const removeCLI = async function removeCLI(funcName) {
   const apiKey = await getAPIKey();
-  return remove(funcName, apiKey);
+  const accountId = await getAccountId(undefined);
+  return remove(accountId, funcName, apiKey);
 };
 
 module.exports = removeCLI;

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { stats } = require('../sdk');
-const { getAPIKey } = require('./userConf');
+const { getAccountId, getAPIKey } = require('./userConf');
 
 /**
  * Retrieves account usage statistics
@@ -11,7 +11,8 @@ const { getAPIKey } = require('./userConf');
  */
 const statsCLI = async function statsCLI(since, until) {
   const apiKey = await getAPIKey();
-  return stats(apiKey, since, until);
+  const accountId = await getAccountId(undefined);
+  return stats(accountId, apiKey, since, until);
 };
 
 module.exports = statsCLI;

--- a/lib/userConf.js
+++ b/lib/userConf.js
@@ -28,7 +28,7 @@ const saveUserConf = async function saveUserConf(userConf) {
  * @param {string} key - key to update conf file with
  * @param {string} value - value to update conf file with
  */
-const updateConf = async function updateAPIKey(key, value) {
+const updateConf = async function updateConf(key, value) {
   let config = {};
   try {
     config = await loadUserConf();

--- a/lib/userConf.js
+++ b/lib/userConf.js
@@ -47,14 +47,15 @@ const getConf = async function getConf(key, envVar, ...defaultValue) {
   let userConf;
   try {
     userConf = await loadUserConf();
-  } catch (err) {
-    // TODO: only ignore file not found / permission errors
-    throw new Error(`Binaris conf file could not be read and ${envVar} is undefined, please use "bn login"`);
-  }
+  } catch (err) {} // eslint-disable-line no-empty
+  // TODO: only ignore file not found / permission errors
 
-  if (!Object.prototype.hasOwnProperty.call(userConf, key)) {
+  if (!userConf || !Object.prototype.hasOwnProperty.call(userConf, key)) {
     if (defaultValue.length === 1) {
       return defaultValue[0];
+    }
+    if (!userConf) {
+      throw new Error(`Binaris conf file could not be read and ${envVar} is undefined, please use "bn login"`);
     }
     throw new Error(
 `Invalid Binaris conf file (missing ${key}) ${userConfPath}`);

--- a/lib/userConf.js
+++ b/lib/userConf.js
@@ -4,6 +4,7 @@ const fs = require('mz/fs');
 const { homedir } = require('os');
 const path = require('path');
 const yaml = require('js-yaml');
+const partial = require('lodash.partial');
 
 const userConfDirectory = process.env.BINARIS_CONF_DIR || process.env.HOME || homedir();
 const userConfFile = '.binaris.yml';
@@ -21,39 +22,49 @@ const saveUserConf = async function saveUserConf(userConf) {
 };
 
 /**
- * Updates the API key of the users Binaris conf file.
- * If no conf file exists when the key update request
- * is sent, one will be created.
+ * Updates a configuration value of the user's Binaris conf file.
+ * If no conf file exists one will be created.
  *
- * @param {string} apiKey - apiKey to update conf file with
+ * @param {string} key - key to update conf file with
+ * @param {string} value - value to update conf file with
  */
-const updateAPIKey = async function updateAPIKey(apiKey) {
+const updateConf = async function updateAPIKey(key, value) {
   let currentConf = {};
   try {
     currentConf = await loadUserConf();
   } catch (err) {} // eslint-disable-line no-empty
-  await saveUserConf(Object.assign({}, currentConf, { apiKey }));
+  // TODO: only ignore file not found / permission errors
+  await saveUserConf(Object.assign({}, currentConf, { [key]: value }));
 };
 
-const getAPIKey = async function getAPIKey() {
-  const apiKey = process.env.BINARIS_API_KEY;
-  if (apiKey) return apiKey;
+const getConf = async function getConf(key, envVar, ...defaultValue) {
+  if (defaultValue.length > 1) {
+    throw new Error(`defaultValue parameter should be an array of 1 or less (got ${defaultValue.length})`);
+  }
+  const value = process.env[envVar];
+  if (value) return value;
 
   let userConf;
   try {
     userConf = await loadUserConf();
   } catch (err) {
-    throw new Error('Binaris conf file could not be read and BINARIS_API_KEY is undefined, please use "bn login"');
+    // TODO: only ignore file not found / permission errors
+    throw new Error(`Binaris conf file could not be read and ${envVar} is undefined, please use "bn login"`);
   }
 
-  if (!Object.prototype.hasOwnProperty.call(userConf, 'apiKey')) {
+  if (!Object.prototype.hasOwnProperty.call(userConf, key)) {
+    if (defaultValue.length === 1) {
+      return defaultValue[0];
+    }
     throw new Error(
-`Invalid Binaris conf file (missing API key) ${userConfPath}`);
+`Invalid Binaris conf file (missing ${key}) ${userConfPath}`);
   }
-  return userConf.apiKey;
+  return userConf[key];
 };
 
 module.exports = {
-  getAPIKey,
-  updateAPIKey,
+  updateAPIKey: partial(updateConf, 'apiKey'),
+  getAPIKey: partial(getConf, 'apiKey', 'BINARIS_API_KEY'),
+  updateAccountId: partial(updateConf, 'accountId'),
+  getAccountId: partial(getConf, 'accountId', 'BINARIS_ACCOUNT_ID'),
 };

--- a/lib/userConf.js
+++ b/lib/userConf.js
@@ -29,12 +29,19 @@ const saveUserConf = async function saveUserConf(userConf) {
  * @param {string} value - value to update conf file with
  */
 const updateConf = async function updateAPIKey(key, value) {
-  let currentConf = {};
+  let config = {};
   try {
-    currentConf = await loadUserConf();
+    config = await loadUserConf();
   } catch (err) {} // eslint-disable-line no-empty
   // TODO: only ignore file not found / permission errors
-  await saveUserConf(Object.assign({}, currentConf, { [key]: value }));
+
+  if (value) {
+    config[key] = value;
+  } else {
+    delete config[key];
+  }
+
+  await saveUserConf(config);
 };
 
 const getConf = async function getConf(key, envVar, ...defaultValue) {
@@ -68,4 +75,6 @@ module.exports = {
   getAPIKey: partial(getConf, 'apiKey', 'BINARIS_API_KEY'),
   updateAccountId: partial(updateConf, 'accountId'),
   getAccountId: partial(getConf, 'accountId', 'BINARIS_ACCOUNT_ID'),
+  updateRealm: partial(updateConf, 'realm'),
+  getRealm: partial(getConf, 'realm', 'realm', ''),
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binaris",
-  "version": "5.4.4",
+  "version": "6.0.0",
   "description": "Binaris SDK & CLI",
   "main": "index.js",
   "bin": {
@@ -21,6 +21,7 @@
     "js-yaml": "^3.11.0",
     "loadtest": "^3.0.3",
     "lodash.get": "^4.4.2",
+    "lodash.partial": "^4.2.1",
     "lodash.sortby": "^4.7.0",
     "moment": "^2.20.1",
     "mz": "^2.7.0",

--- a/sdk/auth.js
+++ b/sdk/auth.js
@@ -1,8 +1,10 @@
 'use strict';
 
+const { inspect } = require('util');
 const urljoin = require('urljoin');
 const rp = require('request-promise-native');
 
+const logger = require('../lib/logger');
 const { getInvokeEndpoint, getDeployEndpoint } = require('./config');
 
 /**
@@ -19,27 +21,28 @@ const verifyAPIKey = async function verifyAPIKey(apiKey) {
         'X-Binaris-Api-Key': apiKey,
       },
       json: true,
-      simple: false,
     });
 
     return {
       error: undefined,
       accountId,
     };
-  } catch (_) {
+  } catch (accountErr) {
+    logger.debug('Failed to authenticate via account', { error: inspect(accountErr) });
     try {
       await rp.get({
         url: urljoin(`https://${getInvokeEndpoint()}`, 'v1', 'apikey', apiKey),
         json: true,
-        simple: false,
       });
+
       return {
         error: undefined,
         accountId: undefined,
       };
-    } catch (err) {
+    } catch (apiErr) {
+      logger.debug('Failed to authenticate via api key', { error: inspect(apiErr) });
       return {
-        error: err,
+        error: new Error('Invalid API key'),
         accountId: undefined,
       };
     }

--- a/sdk/auth.js
+++ b/sdk/auth.js
@@ -3,17 +3,22 @@
 const urljoin = require('urljoin');
 const rp = require('request-promise-native');
 
-const { getInvokeEndpoint } = require('./config');
+const { getDeployEndpoint } = require('./config');
 
 /**
  * Verifies that the provided Binaris API key is correct by
  * querying the remote authentication server.
  *
+ * @param {string} accountId - account ID to validate against
  * @param {string} apiKey - the apiKey to validate
  */
-const verifyAPIKey = async function verifyAPIKey(apiKey) {
+const verifyAPIKey = async function verifyAPIKey(accountId, apiKey) {
+  // TODO: call some new URL in spice
   const options = {
-    url: urljoin(`https://${getInvokeEndpoint()}`, 'v1', 'apikey', apiKey),
+    url: urljoin(`https://${getDeployEndpoint()}`, 'v3', 'authenticate', accountId),
+    headers: {
+      'X-Binaris-Api-Key': apiKey,
+    },
     json: true,
     simple: false,
     resolveWithFullResponse: true,

--- a/sdk/config.js
+++ b/sdk/config.js
@@ -21,7 +21,7 @@ const getLogEndpoint = function getLogEndpoint() {
 const forceRealm = function forceRealm(realm) {
   defaultEndpoints.deploy = `api-${realm}.binaris.com`;
   defaultEndpoints.invoke = `run-${realm}.binaris.com`;
-  defaultEndpoints.logs = `log-${realm}.binaris.com`;
+  defaultEndpoints.logs = `logs-${realm}.binaris.com`;
 };
 
 module.exports = {

--- a/sdk/config.js
+++ b/sdk/config.js
@@ -12,9 +12,16 @@ const getLogEndpoint = function getLogEndpoint() {
   return process.env.BINARIS_LOG_ENDPOINT || 'log.binaris.com';
 };
 
+const forceRealm = function forceRealm(realm) {
+  process.env.BINARIS_DEPLOY_ENDPOINT = process.env.BINARIS_DEPLOY_ENDPOINT || `api-${realm}.binaris.com`;
+  process.env.BINARIS_INVOKE_ENDPOINT = process.env.BINARIS_INVOKE_ENDPOINT || `run-${realm}.binaris.com`;
+  process.env.BINARIS_LOG_ENDPOINT = process.env.BINARIS_LOG_ENDPOINT || `log-${realm}.binaris.com`;
+};
+
 module.exports = {
   getDeployEndpoint,
   getInvokeEndpoint,
   getLogEndpoint,
+  forceRealm,
 };
 

--- a/sdk/config.js
+++ b/sdk/config.js
@@ -1,21 +1,27 @@
 'use strict';
 
+const defaultEndpoints = {
+  deploy: 'api.binaris.com',
+  invoke: 'run.binaris.com',
+  logs: 'log.binaris.com',
+};
+
 const getDeployEndpoint = function getDeployEndpoint() {
-  return process.env.BINARIS_DEPLOY_ENDPOINT || 'api.binaris.com';
+  return process.env.BINARIS_DEPLOY_ENDPOINT || defaultEndpoints.deploy;
 };
 
 const getInvokeEndpoint = function getInvokeEndpoint() {
-  return process.env.BINARIS_INVOKE_ENDPOINT || 'run.binaris.com';
+  return process.env.BINARIS_INVOKE_ENDPOINT || defaultEndpoints.invoke;
 };
 
 const getLogEndpoint = function getLogEndpoint() {
-  return process.env.BINARIS_LOG_ENDPOINT || 'log.binaris.com';
+  return process.env.BINARIS_LOG_ENDPOINT || defaultEndpoints.logs;
 };
 
 const forceRealm = function forceRealm(realm) {
-  process.env.BINARIS_DEPLOY_ENDPOINT = process.env.BINARIS_DEPLOY_ENDPOINT || `api-${realm}.binaris.com`;
-  process.env.BINARIS_INVOKE_ENDPOINT = process.env.BINARIS_INVOKE_ENDPOINT || `run-${realm}.binaris.com`;
-  process.env.BINARIS_LOG_ENDPOINT = process.env.BINARIS_LOG_ENDPOINT || `log-${realm}.binaris.com`;
+  defaultEndpoints.deploy = `api-${realm}.binaris.com`;
+  defaultEndpoints.invoke = `run-${realm}.binaris.com`;
+  defaultEndpoints.logs = `log-${realm}.binaris.com`;
 };
 
 module.exports = {

--- a/sdk/index.js
+++ b/sdk/index.js
@@ -9,6 +9,7 @@ const logs = require('./logs');
 const remove = require('./remove');
 const perf = require('./perf');
 const stats = require('./stats');
+const { forceRealm } = require('./config');
 
 module.exports = {
   auth,
@@ -19,4 +20,5 @@ module.exports = {
   perf,
   remove,
   stats,
+  forceRealm,
 };

--- a/sdk/invoke.js
+++ b/sdk/invoke.js
@@ -1,24 +1,28 @@
 'use strict';
 
-const urljoin = require('urljoin');
 const rp = require('request-promise-native');
 
-const { getInvokeEndpoint } = require('./config');
+const { getInvokeUrl } = require('./url');
 const logger = require('../lib/logger');
 
 /**
  * Invokes a previously deployed Binaris function.
  *
+ * @param {string} accountId - Binaris account id
  * @param {string} funcName - name of the function to invoke
- * @param {string} apiKey - Binaris API key used to authenticate function invocation
+ * @param {string} apiKey - Optional Binaris API key used to authenticate function invocation
  * @param {string} funcData - valid JSON string to send with your invocation
  *
  * @returns {object} - response of function invocation
  */
-const invoke = async function invoke(funcName, apiKey, funcData) {
+const invoke = async function invoke(accountId, funcName, apiKey, funcData) {
+  const baseHeaders = apiKey ? { 'X-Binaris-Api-Key': apiKey } : {};
   const options = {
-    url: urljoin(`https://${getInvokeEndpoint()}`, 'v1', 'run', apiKey, funcName),
-    headers: { 'Content-Type': 'application/json' },
+    url: getInvokeUrl(accountId, funcName, apiKey),
+    headers: {
+      ...baseHeaders,
+      'Content-Type': 'application/json',
+    },
     body: funcData,
     resolveWithFullResponse: true,
   };

--- a/sdk/list.js
+++ b/sdk/list.js
@@ -1,13 +1,14 @@
 'use strict';
 
-const urljoin = require('urljoin');
-
-const { getDeployEndpoint } = require('./config');
+const { getListUrl } = require('./url');
 const { getValidatedBody } = require('./handleError');
 
-const list = async function list(apiKey, endpoint = getDeployEndpoint()) {
+const list = async function list(accountId, apiKey) {
   const listOptions = {
-    url: urljoin(`https://${endpoint}`, 'v2', 'functions', apiKey),
+    url: getListUrl(accountId, apiKey),
+    headers: {
+      'X-Binaris-Api-Key': apiKey,
+    },
     json: true,
   };
   return getValidatedBody(listOptions, 'get');

--- a/sdk/logs.js
+++ b/sdk/logs.js
@@ -1,26 +1,26 @@
 'use strict';
 
-const urljoin = require('urljoin');
 const { loggedRequest, validateResponse } = require('./handleError');
 const logger = require('../lib/logger');
 
-const { getLogEndpoint } = require('./config');
+const { getLogsUrl } = require('./url');
 
 const msleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 /**
  * Retrieves the logs of a previously deployed Binaris function.
  *
- * @param {string} functionName - name of functions whose logs will be retrieved
+ * @param {string} accountId - Binaris account id
+ * @param {string} funcName - name of functions whose logs will be retrieved
  * @param {string} apiKey - Binaris API key used to authenticate function invocation
  * @param {boolean} follow - as in tail -f
  * @param {Date} startAfter - datetime of first log record to fetch
  * @param {string} token - token for fetching next page (returned by this function)
  */
-const logs = async function logs(functionName, apiKey, follow, startAfter, token) { // eslint-disable-line consistent-return,max-len
+const logs = async function logs(accountId, funcName, apiKey, follow, startAfter, token) { // eslint-disable-line consistent-return,max-len
   const options = {
     forever: true,
-    url: urljoin(`https://${getLogEndpoint()}`, 'v1', 'logs', `${apiKey}-${functionName}`),
+    url: getLogsUrl(accountId, funcName, apiKey),
     qs: {
       startAfter,
       token,

--- a/sdk/logs.js
+++ b/sdk/logs.js
@@ -21,6 +21,9 @@ const logs = async function logs(accountId, funcName, apiKey, follow, startAfter
   const options = {
     forever: true,
     url: getLogsUrl(accountId, funcName, apiKey),
+    headers: {
+      'X-Binaris-Api-Key': apiKey,
+    },
     qs: {
       startAfter,
       token,

--- a/sdk/perf.js
+++ b/sdk/perf.js
@@ -1,26 +1,32 @@
 'use strict';
 
-const urljoin = require('urljoin');
 const { loadTest } = require('loadtest');
 
-const { getInvokeEndpoint } = require('./config');
+const { getInvokeUrl } = require('./url');
 const logger = require('../lib/logger');
 
 /**
  * Run performance measurements on deployed function
  *
- * @param {string} apiKey - API Key
+ * @param {string} accountId - Binaris account id
  * @param {string} funcName - name of the function to invoke
+ * @param {string} apiKey - API Key
  * @param {number} maxRequests - How many invocations in total
  * @param {number} concurrency - How many invocations run in parallel
  * @param {number} maxSeconds - Maximum seconds to run
  *
  * @returns {object} - latency report (based on the loadtest npm package)
  */
-const perf = async function perf(apiKey, funcName, maxRequests, concurrency, funcData, maxSeconds) {
+const perf = async function perf(
+  accountId, funcName, apiKey, maxRequests, concurrency, funcData, maxSeconds,
+) {
+  const baseHeaders = apiKey ? { 'X-Binaris-Api-Key': apiKey } : {};
   const options = {
-    url: urljoin(`https://${getInvokeEndpoint()}`, 'v1', 'run', apiKey, funcName),
-    headers: { 'Content-Type': 'application/json' },
+    url: getInvokeUrl(accountId, funcName, apiKey),
+    headers: {
+      ...baseHeaders,
+      'Content-Type': 'application/json',
+    },
     body: funcData,
     // body: TODO: add optional json body
     concurrency,

--- a/sdk/remove.js
+++ b/sdk/remove.js
@@ -1,20 +1,21 @@
 'use strict';
 
-const urljoin = require('urljoin');
-
-const { getDeployEndpoint } = require('./config');
+const { getConfTagUrl } = require('./url');
 const { getValidatedBody } = require('./handleError');
 
 /**
  * Removes the function from the Binaris cloud.
  *
+ * @param {string} accountId - Binaris account ID
  * @param {string} funcName - the name of the function to remove
  * @param {string} apiKey - the apiKey to authenticate the removal with
  */
-const remove = async function remove(funcName, apiKey) {
+const remove = async function remove(accountId, funcName, apiKey) {
   const options = {
-    url: urljoin(`https://${getDeployEndpoint()}`, 'v2', 'tag', apiKey, funcName, 'latest'),
-    json: true,
+    url: getConfTagUrl(accountId, funcName, apiKey, 'latest'),
+    headers: {
+      'X-Binaris-Api-Key': apiKey,
+    },
   };
   return getValidatedBody(options, 'delete');
 };

--- a/sdk/stats.js
+++ b/sdk/stats.js
@@ -1,22 +1,23 @@
 'use strict';
 
-const urljoin = require('urljoin');
 const logger = require('../lib/logger');
 const { getValidatedBody } = require('./handleError');
-
-const { getDeployEndpoint } = require('./config');
+const { getStatsUrl } = require('./url');
 
 /**
  * Retrieves account usage statistics
  *
+ * @param {string} accountId - Binaris account ID
  * @param {string} apiKey - Binaris API key
  * @param {Date} since - All stats since the date-time
  * @param {Date} until - All stats until the date-time
  */
-const stats = async function stats(apiKey, since, until) { // eslint-disable-line consistent-return,max-len
-  const statsURLBase = `https://${getDeployEndpoint()}`;
+const stats = async function stats(accountId, apiKey, since, until) { // eslint-disable-line consistent-return,max-len
   const statsOptions = {
-    url: urljoin(statsURLBase, 'v2', 'metrics', apiKey),
+    url: getStatsUrl(accountId, apiKey),
+    headers: {
+      'X-Binaris-Api-Key': apiKey,
+    },
     body: {
       since,
       until,

--- a/sdk/url.js
+++ b/sdk/url.js
@@ -51,6 +51,14 @@ const getListUrl = function getListUrl(accountId, apiKey) {
   return urljoin(`https://${getDeployEndpoint()}`, 'v3', 'functions', accountId);
 };
 
+const getStatsUrl = function getStatsUrl(accountId, apiKey) {
+  // TODO: remove this when we phase out V1 URLs, this is here to not break current customers' usage
+  if (!accountId) {
+    return urljoin(`https://${getDeployEndpoint()}`, 'v2', 'metrics', apiKey);
+  }
+  return urljoin(`https://${getDeployEndpoint()}`, 'v3', 'metrics', accountId);
+};
+
 module.exports = {
   getCodeUploadUrl,
   getConfUploadUrl,
@@ -58,4 +66,5 @@ module.exports = {
   getInvokeUrl,
   getLogsUrl,
   getListUrl,
+  getStatsUrl,
 };

--- a/sdk/url.js
+++ b/sdk/url.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const urljoin = require('urljoin');
+const { getDeployEndpoint, getInvokeEndpoint, getLogEndpoint } = require('./config');
+
+const getInvokeUrl = function getInvokeUrl(accountId, funcName, apiKey) {
+  // TODO: remove this when we phase out V1 URLs, this is here to not break current customers' usage
+  if (!accountId) {
+    return urljoin(`https://${getInvokeEndpoint()}`, 'v1', 'run', apiKey, funcName);
+  }
+  return urljoin(`https://${getInvokeEndpoint()}`, 'v2', 'run', accountId, funcName);
+};
+
+const getLogsUrl = function getLogsUrl(accountId, funcName, apiKey) {
+  // TODO: remove this when we phase out V1 URLs, this is here to not break current customers' usage
+  if (!accountId) {
+    return urljoin(`https://${getLogEndpoint()}`, 'v1', 'logs', `${apiKey}-${funcName}`);
+  }
+  return urljoin(`https://${getLogEndpoint()}`, 'v2', 'logs', accountId, funcName);
+};
+
+const getCodeUploadUrl = function getCodeUploadUrl(accountId) {
+  // TODO: remove this when we phase out V1 URLs, this is here to not break current customers' usage
+  if (!accountId) {
+    return urljoin(`https://${getDeployEndpoint()}`, 'v2', 'code');
+  }
+  return urljoin(`https://${getDeployEndpoint()}`, 'v3', 'code', accountId);
+};
+
+const getConfUploadUrl = function getConfUploadUrl(accountId, funcName, apiKey) {
+  // TODO: remove this when we phase out V1 URLs, this is here to not break current customers' usage
+  if (!accountId) {
+    return urljoin(`https://${getDeployEndpoint()}`, 'v2', 'conf', apiKey, funcName);
+  }
+  return urljoin(`https://${getDeployEndpoint()}`, 'v3', 'conf', accountId, funcName);
+};
+
+const getConfTagUrl = function getConfTagUploadUrl(accountId, funcName, apiKey, tag) {
+  // TODO: remove this when we phase out V1 URLs, this is here to not break current customers' usage
+  if (!accountId) {
+    return urljoin(`https://${getDeployEndpoint()}`, 'v2', 'tag', apiKey, funcName, tag);
+  }
+  return urljoin(`https://${getDeployEndpoint()}`, 'v3', 'tag', accountId, funcName, tag);
+};
+
+module.exports = {
+  getCodeUploadUrl,
+  getConfUploadUrl,
+  getConfTagUrl,
+  getInvokeUrl,
+  getLogsUrl,
+};

--- a/sdk/url.js
+++ b/sdk/url.js
@@ -43,10 +43,19 @@ const getConfTagUrl = function getConfTagUploadUrl(accountId, funcName, apiKey, 
   return urljoin(`https://${getDeployEndpoint()}`, 'v3', 'tag', accountId, funcName, tag);
 };
 
+const getListUrl = function getListUrl(accountId, apiKey) {
+  // TODO: remove this when we phase out V1 URLs, this is here to not break current customers' usage
+  if (!accountId) {
+    return urljoin(`https://${getDeployEndpoint()}`, 'v2', 'functions', apiKey);
+  }
+  return urljoin(`https://${getDeployEndpoint()}`, 'v3', 'functions', accountId);
+};
+
 module.exports = {
   getCodeUploadUrl,
   getConfUploadUrl,
   getConfTagUrl,
   getInvokeUrl,
   getLogsUrl,
+  getListUrl,
 };

--- a/test/cases.yml
+++ b/test/cases.yml
@@ -38,7 +38,7 @@
   steps:
     -   in: bn create node8 didacticbrothers
     -   in: bn deploy didacticbrothers
-        err: Invalid Binaris conf file (missing API key) /home/dockeruser/.binaris.yml
+        err: Invalid Binaris conf file (missing apiKey) /home/dockeruser/.binaris.yml
         exit: 1
 
 - test: create function with template name

--- a/test/jsApi.yml
+++ b/test/jsApi.yml
@@ -1,126 +1,132 @@
 - test: Test js input
   steps:
+    -   in: export BASE_ARGS="-H X-Binaris-Api-Key:${BINARIS_API_KEY}"
+    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnInput"
     -   in: bn create node8 returnInput
     -   in: 'echo "exports.handler = (input) => ({ inputType: typeof input, input});" >function.js'
     -   in: bn deploy returnInput
-    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnInput"
-    -   in: curl -s "${TEST_FUNCTION}"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '{"inputType":"object","input":{}}'
-    -   in: curl -s --data '{"' "${TEST_FUNCTION}"
+    -   in: curl -s --data '{"' ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '{"inputType":"undefined"}'
-    -   in: curl -s --data '{}' "${TEST_FUNCTION}"
+    -   in: curl -s --data '{}' ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '{"inputType":"object","input":{}}'
-    -   in: curl -s --data '{"foo":"bar","yet":123}' "${TEST_FUNCTION}"
+    -   in: curl -s --data '{"foo":"bar","yet":123}' ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '{"inputType":"object","input":{"foo":"bar","yet":123}}'
-    -   in: curl -s --data '["foo","bar"]' "${TEST_FUNCTION}"
+    -   in: curl -s --data '["foo","bar"]' ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '{"inputType":"object","input":["foo","bar"]}'
     -   in: bn remove returnInput
 
 - test: Test js method 
   steps:
+    -   in: export BASE_ARGS="-H X-Binaris-Api-Key:${BINARIS_API_KEY}"
+    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnMethod"
     -   in: bn create node8 returnMethod
     -   in: 'echo "exports.handler = (_, ctx) => ctx.request.method;" >function.js'
     -   in: bn deploy returnMethod
-    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnMethod"
-    -   in: curl -s -X GET "${TEST_FUNCTION}"
+    -   in: curl -s -X GET ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '"GET"'
-    -   in: curl -s -X POST "${TEST_FUNCTION}"
+    -   in: curl -s -X POST ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '"POST"'
-    -   in: curl -s -X PUT "${TEST_FUNCTION}"
+    -   in: curl -s -X PUT ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '"PUT"'
-    -   in: curl -s -X DELETE "${TEST_FUNCTION}"
+    -   in: curl -s -X DELETE ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '"DELETE"'
-    -   in: curl -s -X OPTIONS "${TEST_FUNCTION}"
+    -   in: curl -s -X OPTIONS ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '"OPTIONS"'
-    -   in: curl -s -X PATCH "${TEST_FUNCTION}"
+    -   in: curl -s -X PATCH ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '"PATCH"'
     -   in: bn remove returnMethod
 
 - test: Test js data input
   steps:
+    -   in: export BASE_ARGS="-H X-Binaris-Api-Key:${BINARIS_API_KEY}"
+    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnReqBody"
     -   in: bn create node8 returnReqBody
     -   in: 'echo "exports.handler = (_, ctx) => ctx.request.body;" >function.js'
     -   in: bn deploy returnReqBody
-    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnReqBody"
-    -   in: curl -s "${TEST_FUNCTION}"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '{"type":"Buffer","data":[]}'
-    -   in: curl -s --data '{' "${TEST_FUNCTION}"
+    -   in: curl -s --data '{' ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '{"type":"Buffer","data":[123]}'
-    -   in: curl -s --data '{}' "${TEST_FUNCTION}"
+    -   in: curl -s --data '{}' ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '{"type":"Buffer","data":[123,125]}'
-    -   in: curl -s --data ' ' "${TEST_FUNCTION}"
+    -   in: curl -s --data ' ' ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '{"type":"Buffer","data":[32]}'
-    -   in: curl -s --data-urlencode ' ' "${TEST_FUNCTION}"
+    -   in: curl -s --data-urlencode ' ' ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '{"type":"Buffer","data":[37,50,48]}'
-    -   in: echo | curl -s --data-binary @- "${TEST_FUNCTION}"
+    -   in: echo | curl -s --data-binary @- ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '{"type":"Buffer","data":[10]}'
-    -   in: echo | gzip -n | curl -s --data-binary @- "${TEST_FUNCTION}"
+    -   in: echo | gzip -n | curl -s --data-binary @- ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '{"type":"Buffer","data":[31,139,8,0,0,0,0,0,0,3,227,2,0,147,6,215,50,1,0,0,0]}'
     -   in: bn remove returnReqBody
 
 - test: Test js headers input
   steps:
+    -   in: export BASE_ARGS="-H X-Binaris-Api-Key:${BINARIS_API_KEY}"
+    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnReqTestHeader"
     -   in: bn create node8 returnReqTestHeader
     -   in: 'echo "exports.handler = (_, ctx) => ctx.request.headers.test;" >function.js'
     -   in: bn deploy returnReqTestHeader
-    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnReqTestHeader"
-    -   in: curl -s "${TEST_FUNCTION}"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}"
         out: ''
-    -   in: 'curl -s -H "Test;" "${TEST_FUNCTION}"'
+    -   in: 'curl -s -H "Test;" ${BASE_ARGS} "${TEST_FUNCTION}"'
         out: '""'
-    -   in: 'curl -s -H "Test: foo" "${TEST_FUNCTION}"'
+    -   in: 'curl -s -H "Test: foo" ${BASE_ARGS} "${TEST_FUNCTION}"'
         out: '"foo"'
-    -   in: 'curl -s -H "Test: 123" "${TEST_FUNCTION}"'
+    -   in: 'curl -s -H "Test: 123" ${BASE_ARGS} "${TEST_FUNCTION}"'
         out: '"123"'
-    -   in: 'curl -s -H "Test: foo" -H "Test: bar" "${TEST_FUNCTION}"'
+    -   in: 'curl -s -H "Test: foo" -H "Test: bar" ${BASE_ARGS} "${TEST_FUNCTION}"'
         out: '"foo, bar"'
     -   in: bn remove returnReqTestHeader
 
 - test: Test js query input
   steps:
+    -   in: export BASE_ARGS="-H X-Binaris-Api-Key:${BINARIS_API_KEY}"
+    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnReqQuery"
     -   in: bn create node8 returnReqQuery
     -   in: 'echo "exports.handler = (_, ctx) => ctx.request.query;" >function.js'
     -   in: bn deploy returnReqQuery
-    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnReqQuery"
-    -   in: curl -s "${TEST_FUNCTION}"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '{}'
-    -   in: curl -s "${TEST_FUNCTION}?foo=123"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}?foo=123"
         out: '{"foo":"123"}'
-    -   in: curl -s "${TEST_FUNCTION}?foo=123&bar=this"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}?foo=123&bar=this"
         out: '{"foo":"123","bar":"this"}'
-    -   in: curl -s "${TEST_FUNCTION}?foo="
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}?foo="
         out: '{"foo":""}'
-    -   in: curl -s "${TEST_FUNCTION}/some/where?foo=123"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}/some/where?foo=123"
         out: '{"foo":"123"}'
-    -   in: curl -s "${TEST_FUNCTION}/some/where/?foo=123&bar=this"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}/some/where/?foo=123&bar=this"
         out: '{"foo":"123","bar":"this"}'
-    -   in: curl -s "${TEST_FUNCTION}?foo="
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}?foo="
         out: '{"foo":""}'
     -   in: bn remove returnReqQuery
 
 - test: Test js path input
   steps:
+    -   in: export BASE_ARGS="-H X-Binaris-Api-Key:${BINARIS_API_KEY}"
+    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnReqPath"
     -   in: bn create node8 returnReqPath
     -   in: 'echo "exports.handler = (_, ctx) => ctx.request.path;" >function.js'
     -   in: bn deploy returnReqPath
-    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnReqPath"
-    -   in: curl -s "${TEST_FUNCTION}"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}"
         out: '"/"'
-    -   in: curl -s "${TEST_FUNCTION}/////"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}/////"
         out: '"/"'
-    -   in: curl -s "${TEST_FUNCTION}/foo"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}/foo"
         out: '"/foo"'
-    -   in: curl -s "${TEST_FUNCTION}/foo?qs"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}/foo?qs"
         out: '"/foo"'
-    -   in: curl -s "${TEST_FUNCTION}/foo/"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}/foo/"
         out: '"/foo/"'
-    -   in: curl -s "${TEST_FUNCTION}/foo/?qs=1"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}/foo/?qs=1"
         out: '"/foo/"'
-    -   in: curl -s "${TEST_FUNCTION}/foo///"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}/foo///"
         out: '"/foo/"'
-    -   in: curl -s "${TEST_FUNCTION}/foo/bar"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}/foo/bar"
         out: '"/foo/bar"'
-    -   in: curl -s "${TEST_FUNCTION}/foo/bar/"
+    -   in: curl -s ${BASE_ARGS} "${TEST_FUNCTION}/foo/bar/"
         out: '"/foo/bar/"'
     -   in: bn remove returnReqPath
 

--- a/test/jsApi.yml
+++ b/test/jsApi.yml
@@ -3,7 +3,7 @@
     -   in: bn create node8 returnInput
     -   in: 'echo "exports.handler = (input) => ({ inputType: typeof input, input});" >function.js'
     -   in: bn deploy returnInput
-    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v1/run/${BINARIS_API_KEY}/returnInput"
+    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnInput"
     -   in: curl -s "${TEST_FUNCTION}"
         out: '{"inputType":"object","input":{}}'
     -   in: curl -s --data '{"' "${TEST_FUNCTION}"
@@ -21,7 +21,7 @@
     -   in: bn create node8 returnMethod
     -   in: 'echo "exports.handler = (_, ctx) => ctx.request.method;" >function.js'
     -   in: bn deploy returnMethod
-    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v1/run/${BINARIS_API_KEY}/returnMethod"
+    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnMethod"
     -   in: curl -s -X GET "${TEST_FUNCTION}"
         out: '"GET"'
     -   in: curl -s -X POST "${TEST_FUNCTION}"
@@ -41,7 +41,7 @@
     -   in: bn create node8 returnReqBody
     -   in: 'echo "exports.handler = (_, ctx) => ctx.request.body;" >function.js'
     -   in: bn deploy returnReqBody
-    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v1/run/${BINARIS_API_KEY}/returnReqBody"
+    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnReqBody"
     -   in: curl -s "${TEST_FUNCTION}"
         out: '{"type":"Buffer","data":[]}'
     -   in: curl -s --data '{' "${TEST_FUNCTION}"
@@ -63,7 +63,7 @@
     -   in: bn create node8 returnReqTestHeader
     -   in: 'echo "exports.handler = (_, ctx) => ctx.request.headers.test;" >function.js'
     -   in: bn deploy returnReqTestHeader
-    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v1/run/${BINARIS_API_KEY}/returnReqTestHeader"
+    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnReqTestHeader"
     -   in: curl -s "${TEST_FUNCTION}"
         out: ''
     -   in: 'curl -s -H "Test;" "${TEST_FUNCTION}"'
@@ -81,7 +81,7 @@
     -   in: bn create node8 returnReqQuery
     -   in: 'echo "exports.handler = (_, ctx) => ctx.request.query;" >function.js'
     -   in: bn deploy returnReqQuery
-    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v1/run/${BINARIS_API_KEY}/returnReqQuery"
+    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnReqQuery"
     -   in: curl -s "${TEST_FUNCTION}"
         out: '{}'
     -   in: curl -s "${TEST_FUNCTION}?foo=123"
@@ -103,7 +103,7 @@
     -   in: bn create node8 returnReqPath
     -   in: 'echo "exports.handler = (_, ctx) => ctx.request.path;" >function.js'
     -   in: bn deploy returnReqPath
-    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v1/run/${BINARIS_API_KEY}/returnReqPath"
+    -   in: export TEST_FUNCTION="https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/returnReqPath"
     -   in: curl -s "${TEST_FUNCTION}"
         out: '"/"'
     -   in: curl -s "${TEST_FUNCTION}/////"
@@ -142,7 +142,7 @@
            }
            EOL
     -   in: bn deploy customResponse
-    -   in: curl --silent --include "https://${BINARIS_INVOKE_ENDPOINT}/v1/run/${BINARIS_API_KEY}/customResponse" | grep -e foo -e bar -e but -e HTTP -e quotes
+    -   in: curl -H X-Binaris-Api-Key:${BINARIS_API_KEY} --silent --include "https://${BINARIS_INVOKE_ENDPOINT}/v2/run/${BINARIS_ACCOUNT_ID}/customResponse" | grep -e foo -e bar -e but -e HTTP -e quotes
         out: |-
              HTTP/1.1 231 unknown
              foo: 123

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -84,7 +84,7 @@
           Deployed function momentousgiants
           Invoke with one of:
             "bn invoke momentousgiants"
-            "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
+            "curl -H X-Binaris-Api-Key:* https://*"
 
 - test: Test create (good-path)
   steps:
@@ -110,13 +110,13 @@
           Deployed function drybeef
           Invoke with one of:
             "bn invoke drybeef"
-            "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
+            "curl -H X-Binaris-Api-Key:* https://*"
     -   in: bn deploy drybeef
         out: |-
           Deployed function drybeef
           Invoke with one of:
             "bn invoke drybeef"
-            "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
+            "curl -H X-Binaris-Api-Key:* https://*"
 
 - test: Test Java
   steps:
@@ -174,7 +174,7 @@
             Deployed function extrasmallaunt
             Invoke with one of:
               "bn invoke extrasmallaunt"
-              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
+              "curl -H X-Binaris-Api-Key:* https://*"
     -   in: cd /home/
     -   in: bn invoke extrasmallaunt
         out: |-
@@ -228,7 +228,7 @@
             Deployed function *
             Invoke with one of:
               "bn invoke *"
-              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
+              "curl -H X-Binaris-Api-Key:* https://*"
     -   in: bn invoke $FUNC_NAME
         out: |-
             "Hello World!"
@@ -290,7 +290,7 @@
             Deployed function *
             Invoke with one of:
               "bn invoke *"
-              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
+              "curl -H X-Binaris-Api-Key:* https://*"
     -   in: |-
           bn invoke $FUNC_NAME -d '{"name": "Binaris"}'
         out: |-
@@ -314,7 +314,7 @@
             Deployed function gulliblezebra
             Invoke with one of:
               "bn invoke gulliblezebra"
-              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
+              "curl -H X-Binaris-Api-Key:* https://*"
     -   in: bn invoke gulliblezebra
         out: |-
             "Hello World!"
@@ -352,7 +352,7 @@
             Deployed function secretsanta
             Invoke with one of:
               "bn invoke secretsanta"
-              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
+              "curl -H X-Binaris-Api-Key:* https://*"
     -   in: bn invoke secretsanta
         out: |-
             *["please","value","*secretsanta"]*
@@ -485,7 +485,7 @@
             Deployed function doomedtofailnode8
             Invoke with one of:
               "bn invoke doomedtofailnode8"
-              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
+              "curl -H X-Binaris-Api-Key:* https://*"
     -   in: bn invoke doomedtofailnode8
         err: |-
             some error
@@ -510,7 +510,7 @@
             Deployed function doomedtofailpy2
             Invoke with one of:
               "bn invoke doomedtofailpy2"
-              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
+              "curl -H X-Binaris-Api-Key:* https://*"
     -   in: bn invoke doomedtofailpy2
         err: |-
             global name 'sdasda' is not defined
@@ -536,7 +536,7 @@
             Deployed function doomedtofailpy3
             Invoke with one of:
               "bn invoke doomedtofailpy3"
-              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
+              "curl -H X-Binaris-Api-Key:* https://*"
     -   in: bn invoke doomedtofailpy3
         err: |-
             name 'sdasda' is not defined
@@ -562,7 +562,7 @@
             Deployed function doomedtofailpy2
             Invoke with one of:
               "bn invoke doomedtofailpy2"
-              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
+              "curl -H X-Binaris-Api-Key:* https://*"
     -   in: bn invoke doomedtofailpypy2
         err: |-
             global name 'sdasda' is not defined
@@ -589,7 +589,7 @@
             Deployed function doomedtofailjava8
             Invoke with one of:
               "bn invoke doomedtofailjava8"
-              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
+              "curl -H X-Binaris-Api-Key:* https://*"
     -   in: bn invoke doomedtofailjava8
         err: |-
             <html>
@@ -750,7 +750,7 @@
           Deployed function *
           Invoke with one of:
             "bn invoke *"
-            "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
+            "curl -H X-Binaris-Api-Key:* https://*"
     - in: bn invoke largeData200MB
       out: |-
           "Hello World!"

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -396,7 +396,7 @@
 
 - test: Test login (bad-path)
   steps:
-    -   in: bn create node8 stormysummer
+    -   in: unset BINARIS_API_KEY
     -   in: echo 9239239 | bn login
         err: Invalid API key
         exit: 1
@@ -559,9 +559,9 @@
             sed -i.bak "2i\    sdasda" function.py
     -   in: bn deploy doomedtofailpypy2
         out: |-
-            Deployed function doomedtofailpy2
+            Deployed function doomedtofailpypy2
             Invoke with one of:
-              "bn invoke doomedtofailpy2"
+              "bn invoke doomedtofailpypy2"
               "curl -H X-Binaris-Api-Key:* https://*"
     -   in: bn invoke doomedtofailpypy2
         err: |-
@@ -599,7 +599,7 @@
             </head>
             <body>
             <h2>HTTP ERROR: 500</h2>
-            <p>Problem accessing /v2/run. Reason:
+            <p>Problem accessing /v1/run. Reason:
             <pre>    class java.lang.Error</pre></p>
             <hr /><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.3.z-SNAPSHOT</a><hr/>
             </body>

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -72,11 +72,10 @@
         out: |-
             Created function * in /home/dockeruser/test
               (use "bn deploy momentousgiants" to deploy the function)
-    -   in: echo "$BINARIS_ACCOUNT_ID\n$BINARIS_API_KEY" | bn login
+    -   in: echo $BINARIS_API_KEY | bn login
         out: |-
-            Please enter your Binaris account ID and API key to deploy and invoke functions.
-            If you don't have an account ID or key, head over to https://binaris.com to request one
-            *? Account ID: *
+            Please enter your Binaris API key to deploy and invoke functions.
+            If you don't have a key, head over to https://binaris.com to request one
             *? API Key: *
             *Authentication Succeeded*
               (use "bn create node8 hello" to create a Node.js template function in your CWD)
@@ -398,7 +397,7 @@
 - test: Test login (bad-path)
   steps:
     -   in: bn create node8 stormysummer
-    -   in: echo "$BINARIS_ACCOUNT_ID\n9239239" | bn login
+    -   in: echo 9239239 | bn login
         err: Invalid API key
         exit: 1
 

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -64,30 +64,37 @@
                   bn logs foo --since 9s*
 
 - test: Test old endpoints
+  setup:
+    - export FUNC_NAME=rand$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 32 | head -n 1)
+    - bn create node8 $FUNC_NAME
+    - unset BINARIS_API_KEY
+    - unset BINARIS_ACCOUNT_ID
   cleanup:
-    - bn remove momentousgiants
+    - bn remove $FUNC_NAME
   steps:
-    -   in: unset BINARIS_API_KEY
-    -   in: unset BINARIS_ACCOUNT_ID
-    -   in: bn create node8 momentousgiants
-        out: |-
-            Created function * in /home/dockeruser/test
-              (use "bn deploy momentousgiants" to deploy the function)
-    -   in: echo $BINARIS_TEMPORARY_API_KEY_FOR_TESTING_OLD_ENDPOINTS | bn login
-        out: |-
-            Please enter your Binaris API key to deploy and invoke functions.
-            If you don't have a key, head over to https://binaris.com to request one
-            *? API Key: *
-            *Authentication Succeeded*
-              (use "bn create node8 hello" to create a Node.js template function in your CWD)
-    -   in: bn deploy momentousgiants
-        out: |-
-          Deployed function momentousgiants
-          Invoke with one of:
-            "bn invoke momentousgiants"
-            "curl -H X-Binaris-Api-Key:* https://*"
-    -   in: bn invoke momentousgiants
-        out: '"Hello World!"'
+    - in: echo $BINARIS_TEMPORARY_API_KEY_FOR_TESTING_OLD_ENDPOINTS | bn login
+      out: |-
+          Please enter your Binaris API key to deploy and invoke functions.
+          If you don't have a key, head over to https://binaris.com to request one
+          *? API Key: *
+          *Authentication Succeeded*
+            (use "bn create node8 hello" to create a Node.js template function in your CWD)
+    - in: bn deploy $FUNC_NAME
+      out: |-
+        Deployed function *
+        Invoke with one of:
+          "bn invoke *"
+          "curl -H X-Binaris-Api-Key:* https://*"
+    - in: bn invoke $FUNC_NAME
+      out: '"Hello World!"'
+    - in: sleep 5
+    - in: bn logs $FUNC_NAME
+      out: |-
+        [201*-*-*T*:*:*Z] Function * deployed (version digest: *)
+        [201*-*-*T*:*:*Z] Function invocation took * us
+    - in: bn list --json
+      out: |-
+        *[*{"name":"rand*","lastDeployed":"[20*-*-*T*:*:*Z]"}*]*
 
 - test: Test login (good-path)
   cleanup:

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -15,7 +15,6 @@
                 bn list [options]                         List all deployed functions
                 bn perf <function> [options]              Measure invocation latency (experimental)
                 bn logs <function> [options]              Print the logs of a function
-                bn stats [options]                        Print usage statistics
                 bn login                                  Login to your Binaris account using an API key and account id
 
               Options:

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -63,6 +63,32 @@
                   bn logs foo --since 13hours
                   bn logs foo --since 9s*
 
+- test: Test old endpoints
+  cleanup:
+    - bn remove momentousgiants
+  steps:
+    -   in: unset BINARIS_API_KEY
+    -   in: unset BINARIS_ACCOUNT_ID
+    -   in: bn create node8 momentousgiants
+        out: |-
+            Created function * in /home/dockeruser/test
+              (use "bn deploy momentousgiants" to deploy the function)
+    -   in: echo $BINARIS_TEMPORARY_API_KEY_FOR_TESTING_OLD_ENDPOINTS | bn login
+        out: |-
+            Please enter your Binaris API key to deploy and invoke functions.
+            If you don't have a key, head over to https://binaris.com to request one
+            *? API Key: *
+            *Authentication Succeeded*
+              (use "bn create node8 hello" to create a Node.js template function in your CWD)
+    -   in: bn deploy momentousgiants
+        out: |-
+          Deployed function momentousgiants
+          Invoke with one of:
+            "bn invoke momentousgiants"
+            "curl -H X-Binaris-Api-Key:* https://*"
+    -   in: bn invoke momentousgiants
+        out: '"Hello World!"'
+
 - test: Test login (good-path)
   cleanup:
     - bn remove momentousgiants

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -16,7 +16,7 @@
                 bn perf <function> [options]              Measure invocation latency (experimental)
                 bn logs <function> [options]              Print the logs of a function
                 bn stats [options]                        Print usage statistics
-                bn login                                  Login to your Binaris account using an API key
+                bn login                                  Login to your Binaris account using an API key and account id
 
               Options:
                 --version   Show version number  [boolean]
@@ -72,17 +72,20 @@
         out: |-
             Created function * in /home/dockeruser/test
               (use "bn deploy momentousgiants" to deploy the function)
-    -   in: echo "$BINARIS_API_KEY" | bn login
+    -   in: echo "$BINARIS_ACCOUNT_ID\n$BINARIS_API_KEY" | bn login
         out: |-
-            Please enter your Binaris API key to deploy and invoke functions.
-            If you don't have a key, head over to https://binaris.com to request one
+            Please enter your Binaris account ID and API key to deploy and invoke functions.
+            If you don't have an account ID or key, head over to https://binaris.com to request one
+            *? Account ID: *
             *? API Key: *
             *Authentication Succeeded*
               (use "bn create node8 hello" to create a Node.js template function in your CWD)
     -   in: bn deploy momentousgiants
         out: |-
-            Deployed function to *
-              (use "bn invoke momentousgiants" to invoke the function)
+          Deployed function momentousgiants
+          Invoke with one of:
+            "bn invoke momentousgiants"
+            "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
 
 - test: Test create (good-path)
   steps:
@@ -105,12 +108,16 @@
               (use "bn deploy drybeef" to deploy the function)
     -   in: bn deploy drybeef
         out: |-
-            Deployed function to *
-              (use "bn invoke drybeef" to invoke the function)
+          Deployed function drybeef
+          Invoke with one of:
+            "bn invoke drybeef"
+            "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
     -   in: bn deploy drybeef
         out: |-
-            Deployed function to *
-              (use "bn invoke drybeef" to invoke the function)
+          Deployed function drybeef
+          Invoke with one of:
+            "bn invoke drybeef"
+            "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
 
 - test: Test Java
   steps:
@@ -165,8 +172,10 @@
               (use "bn deploy extrasmallaunt" to deploy the function)
     -   in: bn deploy extrasmallaunt
         out: |-
-            Deployed function to *
-              (use "bn invoke extrasmallaunt" to invoke the function)
+            Deployed function extrasmallaunt
+            Invoke with one of:
+              "bn invoke extrasmallaunt"
+              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
     -   in: cd /home/
     -   in: bn invoke extrasmallaunt
         out: |-
@@ -217,8 +226,10 @@
   steps:
     -   in: bn deploy $FUNC_NAME
         out: |-
-            Deployed function to *
-              (use "bn invoke *" to invoke the function)
+            Deployed function *
+            Invoke with one of:
+              "bn invoke *"
+              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
     -   in: bn invoke $FUNC_NAME
         out: |-
             "Hello World!"
@@ -277,8 +288,10 @@
   steps:
     -   in: bn deploy $FUNC_NAME
         out: |-
-            Deployed function to *
-              (use "bn invoke *" to invoke the function)
+            Deployed function *
+            Invoke with one of:
+              "bn invoke *"
+              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
     -   in: |-
           bn invoke $FUNC_NAME -d '{"name": "Binaris"}'
         out: |-
@@ -299,8 +312,10 @@
             echo 'exports.handler = () => { s = "Hello World!"; console.log(s); return s; };' >function.js
     -   in: bn deploy gulliblezebra
         out: |-
-            Deployed function to *
-              (use "bn invoke gulliblezebra" to invoke the function)
+            Deployed function gulliblezebra
+            Invoke with one of:
+              "bn invoke gulliblezebra"
+              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
     -   in: bn invoke gulliblezebra
         out: |-
             "Hello World!"
@@ -335,8 +350,10 @@
             EOF
     -   in: FORWARD_ME=please bn deploy secretsanta
         out: |-
-            Deployed function to *
-              (use "bn invoke secretsanta" to invoke the function)
+            Deployed function secretsanta
+            Invoke with one of:
+              "bn invoke secretsanta"
+              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
     -   in: bn invoke secretsanta
         out: |-
             *["please","value","*secretsanta"]*
@@ -381,7 +398,7 @@
 - test: Test login (bad-path)
   steps:
     -   in: bn create node8 stormysummer
-    -   in: echo "9239239" | bn login
+    -   in: echo "$BINARIS_ACCOUNT_ID\n9239239" | bn login
         err: Invalid API key
         exit: 1
 
@@ -466,8 +483,10 @@
             sed -i.bak "2i\  throw new Error('some error');" function.js
     -   in: bn deploy doomedtofailnode8
         out: |-
-            Deployed function to *
-              (use "bn invoke doomedtofailnode8" to invoke the function)
+            Deployed function doomedtofailnode8
+            Invoke with one of:
+              "bn invoke doomedtofailnode8"
+              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
     -   in: bn invoke doomedtofailnode8
         err: |-
             some error
@@ -489,8 +508,10 @@
             sed -i.bak "2i\    sdasda" function.py
     -   in: bn deploy doomedtofailpy2
         out: |-
-            Deployed function to *
-              (use "bn invoke doomedtofailpy2" to invoke the function)
+            Deployed function doomedtofailpy2
+            Invoke with one of:
+              "bn invoke doomedtofailpy2"
+              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
     -   in: bn invoke doomedtofailpy2
         err: |-
             global name 'sdasda' is not defined
@@ -513,8 +534,10 @@
             sed -i.bak "2i\    sdasda" function.py
     -   in: bn deploy doomedtofailpy3
         out: |-
-            Deployed function to *
-              (use "bn invoke doomedtofailpy3" to invoke the function)
+            Deployed function doomedtofailpy3
+            Invoke with one of:
+              "bn invoke doomedtofailpy3"
+              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
     -   in: bn invoke doomedtofailpy3
         err: |-
             name 'sdasda' is not defined
@@ -537,8 +560,10 @@
             sed -i.bak "2i\    sdasda" function.py
     -   in: bn deploy doomedtofailpypy2
         out: |-
-            Deployed function to *
-              (use "bn invoke doomedtofailpypy2" to invoke the function)
+            Deployed function doomedtofailpy2
+            Invoke with one of:
+              "bn invoke doomedtofailpy2"
+              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
     -   in: bn invoke doomedtofailpypy2
         err: |-
             global name 'sdasda' is not defined
@@ -562,8 +587,10 @@
     -   in: gradle jar
     -   in: bn deploy doomedtofailjava8
         out: |-
-            Deployed function to *
-              (use "bn invoke doomedtofailjava8" to invoke the function)
+            Deployed function doomedtofailjava8
+            Invoke with one of:
+              "bn invoke doomedtofailjava8"
+              "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
     -   in: bn invoke doomedtofailjava8
         err: |-
             <html>
@@ -573,7 +600,7 @@
             </head>
             <body>
             <h2>HTTP ERROR: 500</h2>
-            <p>Problem accessing /v1/run. Reason:
+            <p>Problem accessing /v2/run. Reason:
             <pre>    class java.lang.Error</pre></p>
             <hr /><a href="http://eclipse.org/jetty">Powered by Jetty:// 9.3.z-SNAPSHOT</a><hr/>
             </body>
@@ -721,8 +748,10 @@
   steps:
     - in: bn deploy largeData200MB
       out: |-
-          Deployed function to *
-            (use "bn invoke *" to invoke the function)
+          Deployed function *
+          Invoke with one of:
+            "bn invoke *"
+            "curl -H X-Binaris-Api-Key:${X_BINARIS_API_KEY} https://*"
     - in: bn invoke largeData200MB
       out: |-
           "Hello World!"

--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,7 @@ const Container = require('./helpers/container');
 
 const propagatedEnvVars = [
   'BINARIS_API_KEY',
+  'BINARIS_ACCOUNT_ID',
   'BINARIS_DEPLOY_ENDPOINT',
   'BINARIS_INVOKE_ENDPOINT',
   'BINARIS_LOG_ENDPOINT'];

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,7 @@ const regEsc = require('escape-string-regexp');
 const Container = require('./helpers/container');
 
 const propagatedEnvVars = [
+  'BINARIS_TEMPORARY_API_KEY_FOR_TESTING_OLD_ENDPOINTS',
   'BINARIS_API_KEY',
   'BINARIS_ACCOUNT_ID',
   'BINARIS_DEPLOY_ENDPOINT',


### PR DESCRIPTION
Implements the V2 spec (for KubeCon).
Should theoretically support pre account URLs when `accountId` is not found to avoid breaking current customers' integrations.
Depends on integration from other services with this branch.

CC: @michaeladda 
