### PR TITLE
Undocument the stats command.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -230,7 +230,7 @@ Usage: $0 <command> [options]` // eslint-disable-line comma-dangle
     }
     await handleCommand(argv, logsHandler);
   })
-  .command('stats [options]', 'Print usage statistics', (yargs0) => {
+  .command('stats [options]', /* hidden: 'Print usage statistics' */ false, (yargs0) => {
     yargs0
       .usage('Usage: $0 stats [options]')
       .option('since', {

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -15,7 +15,6 @@
                 bn list [options]                         List all deployed functions
                 bn perf <function> [options]              Measure invocation latency (experimental)
                 bn logs <function> [options]              Print the logs of a function
-                bn stats [options]                        Print usage statistics
                 bn login                                  Login to your Binaris account using an API key and account id
 
               Options:


### PR DESCRIPTION
Not currently useful for most users.

Fixes #394 .