### PR TITLE
Allow underscores in function names

### DIFF
--- a/lib/nameUtil.js
+++ b/lib/nameUtil.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // allows only letters and numbers
-const validNameRegex = /[^A-Za-z0-9]/g;
+const validNameRegex = /[^A-Za-z0-9_]/g;
 
 /**
  * Verifies whether the provided function name meets


### PR DESCRIPTION
Not changing the functionality of validation on `cli` to avoid the round-trip to binaris API.