### PR TITLE
fix default realm logs endpoint

### DIFF
--- a/sdk/config.js
+++ b/sdk/config.js
@@ -21,7 +21,7 @@ const getLogEndpoint = function getLogEndpoint() {
 const forceRealm = function forceRealm(realm) {
   defaultEndpoints.deploy = `api-${realm}.binaris.com`;
   defaultEndpoints.invoke = `run-${realm}.binaris.com`;
-  defaultEndpoints.logs = `log-${realm}.binaris.com`;
+  defaultEndpoints.logs = `logs-${realm}.binaris.com`;
 };
 
 module.exports = {


### PR DESCRIPTION
fixes #400
according to picard tf the log endpoint is really `logs-${realm}`
sadly since the CI uses env vars this logic is not really tested currently