### PR TITLE
Only report login errors when no connection errors occurred

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binaris",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Binaris SDK & CLI",
   "main": "index.js",
   "bin": {

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -457,6 +457,26 @@
             Tip: You can export BINARIS_LOG_LEVEL=[silly|debug|verbose] to view debug logs
         exit: 1
 
+- test: Test login endpoint error (bad-path)
+  steps:
+    -   in: unset BINARIS_API_KEY
+    -   in: echo 9239239 | BINARIS_DEPLOY_ENDPOINT=fake.api.binaris.invalid. bn login
+        err: "Error: getaddrinfo ENOTFOUND fake.api.binaris.invalid. fake.api.binaris.invalid.:443"
+        out: |-
+            *
+            Tip: You can export BINARIS_LOG_LEVEL=[silly|debug|verbose] to view debug logs
+        exit: 1
+
+- test: Test login backcompat endpoint error (bad-path)
+  steps:
+    -   in: unset BINARIS_API_KEY
+    -   in: echo 9239239 | BINARIS_INVOKE_ENDPOINT=fake.run.binaris.invalid. bn login
+        err: "Error: getaddrinfo ENOTFOUND fake.run.binaris.invalid. fake.run.binaris.invalid.:443"
+        out: |-
+            *
+            Tip: You can export BINARIS_LOG_LEVEL=[silly|debug|verbose] to view debug logs
+        exit: 1
+
 - test: Test create (bad-path)
   steps:
     -   in: bn create node8 a*b*c*


### PR DESCRIPTION
Fixes #399.

Added test using failing DNS, but ECONNREFUSED and similar should work in the same way.