### PR TITLE
use only package version as git tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ test: build
 
 .PHONY: publish
 publish: require-npm-creds require-npm-tag
-		git tag $(version)/$(NPM_TAG)
-		git push origin $(version)/$(NPM_TAG)
+		git tag $(version)
+		git push origin $(version)
 		export tag=$(tag)
 		$(DOCKER) run                                                                                              \
 			--rm                                                                                                     \


### PR DESCRIPTION
since npm version are immutable, but npm tags are mutable,
it makes more sense to have the git tag match the immutable npm
specifier.

not tested unfortunately. will test soon, when i'll publish a new cli