### PR TITLE
Use error messages from server in more cases.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binaris",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "description": "Binaris SDK & CLI",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Binaris",
   "license": "MIT",
   "dependencies": {
-    "binaris-pickle": "^1.1.0",
+    "binaris-pickle": "^1.1.2",
     "columnify": "^1.5.4",
     "escape-string-regexp": "^1.0.5",
     "fs-extra": "^4.0.3",

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -926,13 +926,13 @@
     -   in: bn create node8 $SERVER_LONG_NAME
     -   in: bn deploy $SERVER_LONG_NAME
         exit: 1
-        err: "Error: ERR_FUNCTION_NAME_TOO_LONG"
+        err: "Function name cannot be longer than 200"
 
 - test: Test remove of somewhat long name (bad-path)
   steps:
     -   in: bn remove binarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinarisbinaris
         exit: 1
-        err: "Error: ERR_FUNCTION_NAME_TOO_LONG"
+        err: "Function name cannot be longer than 200"
 
 - test: Test deploy of very long name (bad-path)
   setup:


### PR DESCRIPTION
* If no translation exists for error, use a server-supplied error
  message on `error`.
* If server reports anything with an `errorCode`, also allow a message
  on the `message` attribute (but prefer a translation).
* If server reports anything with an `errorCode` that has no `error`,
  no `message`, and no translation, report just the code.

Fixes #410.

DO NOT PULL before publishing binaris/pickle 1.1.2 (binaris/pickle#6).