### PR TITLE
Allow only ASCII characters in API key and account ID fields

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,14 @@ const logger = require('./logger');
 const perf = require('./perf');
 const remove = require('./remove');
 const YMLUtil = require('./binarisYML');
-const { getAPIKey, getAccountId, updateAccountId, updateAPIKey, updateRealm } = require('./userConf');
+const {
+  getAPIKey,
+  getAccountId,
+  updateAccountId,
+  updateAPIKey,
+  updateRealm,
+  validateHeaderValue,
+} = require('./userConf');
 const { auth, forceRealm } = require('../sdk');
 const { validateName } = require('./nameUtil');
 const sortBy = require('lodash.sortby');
@@ -275,6 +282,8 @@ If you don't have a key, head over to https://binaris.com to request one`);
     },
   ]);
 
+  validateHeaderValue(rawApiKey, 'API key');
+
   const apiKeyIdx = rawApiKey.lastIndexOf('-');
   const apiKey = rawApiKey.substr(apiKeyIdx + 1);
   const realm = rawApiKey.substr(0, apiKeyIdx);
@@ -283,6 +292,8 @@ If you don't have a key, head over to https://binaris.com to request one`);
     forceRealm(realm);
   }
   const { accountId, error } = await auth.verifyAPIKey(apiKey);
+  // (Don't validate accountId, it comes from Binaris so not a
+  // keyboard entry issue.)
   if (error) {
     throw error;
   }

--- a/lib/userConf.js
+++ b/lib/userConf.js
@@ -69,11 +69,35 @@ const getConf = async function getConf(key, envVar, ...defaultValue) {
   return userConf[key];
 };
 
+// Matches printable ASCII-only values.
+const ascii = /^[\u0020-\u007E]*$/;
+
+// Validates a header can be sent.  In practice ISO 8859-1 is allowed,
+// but that is rejected by the Binaris backend.  Disallow it on
+// principle, for aesthetic reasons
+const validateHeaderValue = function validateHeaderValue(value, context) {
+  if (!ascii.test(value)) {
+    throw new Error(`Non-ASCII characters are not allowed in ${context}.`);
+  }
+  return value;
+};
+
+// Wraps func in validateHeaderValue.
+const validateGet = function validateGet(func, context) {
+  return async function get(...args) { return validateHeaderValue(await func(...args), context); };
+};
+
+// Wraps func argument in validateHeaderValue.
+const validateUpdate = function validateUpdate(func, context) {
+  return async function update(value) { await func(validateHeaderValue(value, context)); };
+};
+
 module.exports = {
-  updateAPIKey: partial(updateConf, 'apiKey'),
-  getAPIKey: partial(getConf, 'apiKey', 'BINARIS_API_KEY'),
-  updateAccountId: partial(updateConf, 'accountId'),
-  getAccountId: partial(getConf, 'accountId', 'BINARIS_ACCOUNT_ID'),
+  validateHeaderValue,
+  updateAPIKey: validateUpdate(partial(updateConf, 'apiKey'), 'API key'),
+  getAPIKey: validateGet(partial(getConf, 'apiKey', 'BINARIS_API_KEY'), 'API key'),
+  updateAccountId: validateUpdate(partial(updateConf, 'accountId'), 'account ID'),
+  getAccountId: validateGet(partial(getConf, 'accountId', 'BINARIS_ACCOUNT_ID'), 'account ID'),
   updateRealm: partial(updateConf, 'realm'),
   getRealm: partial(getConf, 'realm', 'realm', ''),
 };

--- a/lib/userConf.js
+++ b/lib/userConf.js
@@ -77,7 +77,7 @@ const ascii = /^[\u0020-\u007E]*$/;
 // principle, for aesthetic reasons
 const validateHeaderValue = function validateHeaderValue(value, context) {
   if (!ascii.test(value)) {
-    throw new Error(`Non-ASCII characters are not allowed in ${context}.`);
+    throw new Error(`Non-ASCII characters are not allowed in ${context}`);
   }
   return value;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binaris",
-  "version": "6.0.8",
+  "version": "6.0.9",
   "description": "Binaris SDK & CLI",
   "main": "index.js",
   "bin": {

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -77,7 +77,7 @@
   cleanup:
     - bn remove $FUNC_NAME
   steps:
-    - in: echo $BINARIS_TEMPORARY_API_KEY_FOR_TESTING_OLD_ENDPOINTS | bn login
+    - in: echo "$BINARIS_TEMPORARY_API_KEY_FOR_TESTING_OLD_ENDPOINTS" | bn login
       out: |-
           Please enter your Binaris API key to deploy and invoke functions.
           If you don't have a key, head over to https://binaris.com to request one
@@ -808,6 +808,33 @@
             Unauthorized request. Make sure you're passing the right API key.
             request_id: *
         exit: 1
+
+- test: Invalid characters in API key when invoking (bad-path)
+  setup:
+    - export BINARIS_API_KEY=יוניקוד
+  steps:
+    - in: bn invoke whatever
+      err: |-
+        Non-ASCII characters are not allowed in API key.
+      exit: 1
+
+- test: Invalid characters in API key when logging in (bad-path)
+  setup:
+    - export BINARIS_API_KEY=יוניקוד
+  steps:
+    - in: echo $BINARIS_API_KEY | bn login
+      err: |-
+        Non-ASCII characters are not allowed in API key.
+      exit: 1
+
+- test: Invalid characters in account ID from environment variable (bad-path)
+  setup:
+    - export BINARIS_ACCOUNT_ID=יוניקוד
+  steps:
+    - in: bn invoke whatever
+      err: |-
+        Non-ASCII characters are not allowed in account ID.
+      exit: 1
 
 - test: Deploy of 200MB function succeeds
   setup:

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -815,7 +815,7 @@
   steps:
     - in: bn invoke whatever
       err: |-
-        Non-ASCII characters are not allowed in API key.
+        Non-ASCII characters are not allowed in API key
       exit: 1
 
 - test: Invalid characters in API key when logging in (bad-path)
@@ -824,7 +824,7 @@
   steps:
     - in: echo $BINARIS_API_KEY | bn login
       err: |-
-        Non-ASCII characters are not allowed in API key.
+        Non-ASCII characters are not allowed in API key
       exit: 1
 
 - test: Invalid characters in account ID from environment variable (bad-path)
@@ -833,7 +833,7 @@
   steps:
     - in: bn invoke whatever
       err: |-
-        Non-ASCII characters are not allowed in account ID.
+        Non-ASCII characters are not allowed in account ID
       exit: 1
 
 - test: Deploy of 200MB function succeeds


### PR DESCRIPTION
They must be compatible with HTTP headers, and we don't bother to encode them according to the RFCs.  So they should be just ISO 8859-1, and because we don't care about those extra characters we just go with ASCII.

Why not encode non-ASCII into the headers?  Apart from being a lot of work for no gain, there's actual harm in having to support multiple encodings of the same field.  E.g. much fun would be had with X.509 / PKCS certificates had DNs not been encoded canonically.  ASCII is so much easier to think about, and we control both ends to can do as we like.