### PR TITLE
Include debug ID in internal error messages

### DIFF
--- a/sdk/handleError.js
+++ b/sdk/handleError.js
@@ -12,12 +12,20 @@ const { version } = require('../package.json');
 
 class APIError extends Error {}
 
+function appendDebugId(message, debugId) {
+  if (debugId) {
+    return `${message}\nPlease refer to the request ID: ${debugId} for support on this error`;
+  }
+  return message;
+}
+
 function validateResponse(response) {
   const errorCode = get(response, 'body.errorCode');
+  const debugId = get(response, 'body.debugId');
   if (errorCode) {
     const readableErrorMessage = maybeTranslateErrorCode(errorCode);
     if (readableErrorMessage) {
-      throw new APIError(`Error: ${readableErrorMessage}`);
+      throw new APIError(appendDebugId(`Error: ${readableErrorMessage}`, errorCode === 'ERR_INTERNAL' && debugId));
     }
   }
 


### PR DESCRIPTION
Re-ran multiple times to get the error to show up.

Done for specific `ERR_INTERNAL` and not in a generic way since extra info is probably unneeded for errors like `No such function` or `Invalid API key`.