### PR TITLE
Avoid printing security sensitive apiKey to terminal during deploy

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -110,11 +110,10 @@ const createHandler = async function createHandler(options) {
  */
 const deployHandler = async function deployHandler(options) {
   const meta = await gatherMeta(options);
-  const apiKey = await getAPIKey();
   const accountId = await getAccountId(undefined);
   const endpoint = await deploy(meta.name, meta.path, meta.conf);
 
-  const apiHeader = `-H X-Binaris-Api-Key:${apiKey} `;
+  const apiHeader = '-H X-Binaris-Api-Key:$(bn show apiKey) ';
   const printHeader = accountId !== undefined && !meta.name.startsWith('public_');
 
   logger.info(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binaris",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "Binaris SDK & CLI",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Tested locally that the generated command works.