### PR TITLE
Feature debug id in errors

### DIFF
--- a/sdk/handleError.js
+++ b/sdk/handleError.js
@@ -14,7 +14,7 @@ class APIError extends Error {
   constructor(message, requestId) {
     super(message);
     const requestIdString = requestId ? `RequestId: ${requestId}\n` : '';
-    this.message = `${requestIdString}${message}`);
+    this.message = `${requestIdString}${message}`;
   }
 }
 

--- a/sdk/handleError.js
+++ b/sdk/handleError.js
@@ -17,7 +17,7 @@ class APIError extends Error {
 }
 
 function validateResponse(response) {
-  const requestId = get(response, 'headers.X-Binaris-Request-ID');
+  const requestId = get(response, 'headers.x-binaris-request-id');
   const requestIdString = requestId ? `RequestId: ${requestId}\n` : '';
   const errorCode = get(response, 'body.errorCode');
   if (errorCode) {

--- a/sdk/handleError.js
+++ b/sdk/handleError.js
@@ -12,9 +12,8 @@ const { version } = require('../package.json');
 
 class APIError extends Error {
   constructor(message, requestId) {
-    super(message);
     const requestIdString = requestId ? `RequestId: ${requestId}\n` : '';
-    this.message = `${requestIdString}${message}`;
+    super(`${requestIdString}${message}`);
   }
 }
 

--- a/sdk/invoke.js
+++ b/sdk/invoke.js
@@ -39,7 +39,7 @@ const invoke = async function invoke(accountId, funcName, apiKey, funcData) {
       const fullError = [`RequestId: ${requestId}`];
       try {
         const parsedError = JSON.parse(err.response.body);
-        fullError.push(parsedError.error);
+        fullError.push(parsedError.error || parsedError.message);
         if (parsedError.stack) {
           fullError.push(parsedError.stack);
         }

--- a/sdk/invoke.js
+++ b/sdk/invoke.js
@@ -34,9 +34,15 @@ const invoke = async function invoke(accountId, funcName, apiKey, funcData) {
     logger.debug('Invoke response', { statusCode, headers, body });
     return res;
   } catch (err) {
+    const fallbackError = err.error || err;
     if (err instanceof StatusCodeError) {
       const requestId = err.response.headers['x-binaris-request-id'];
-      const parsedError = JSON.parse(err.error);
+      let parsedError;
+      try {
+        parsedError = JSON.parse(err.error);
+      } catch (parseError) {
+        parsedError = { error: fallbackError };
+      }
       const fullError = [`RequestId: ${requestId}`, parsedError.error || parsedError.message];
 
       if (parsedError.stack) {
@@ -45,7 +51,7 @@ const invoke = async function invoke(accountId, funcName, apiKey, funcData) {
       throw new Error(fullError.join('\n'));
     }
 
-    throw new Error(err.error || err);
+    throw new Error(fallbackError);
   }
 };
 

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -743,7 +743,7 @@
     -   in: bn create node8 dispensabledrop
     -   in: bn remove dispensabledrop
         err: |-
-            DebugId: *
+            RequestId: *
             Error: No such function
         exit: 1
     -   in: bn deploy dispensabledrop
@@ -751,7 +751,7 @@
         out: "*Removed function dispensabledrop*"
     -   in: bn remove dispensabledrop
         err: |-
-            DebugId: *
+            RequestId: *
             Error: No such function
         exit: 1
     -   in: bn remove
@@ -868,12 +868,12 @@
     -   in: bn create node8 perplexingpersimmon
     -   in: bn deploy perplexingpersimmon
         err: |-
-            DebugId: *
+            RequestId: *
             Error: Invalid API key
         exit: 1
     -   in: bn list
         err: |-
-            DebugId: *
+            RequestId: *
             Error: Invalid API key
         exit: 1
     -   in: BINARIS_API_KEY=boguskey bn invoke perplexingpersimmon
@@ -1006,7 +1006,7 @@
   steps:
     - in: bn deploy largeData300MB
       err: |-
-        DebugId: *
+        RequestId: *
         Error: Payload too large
       exit: 1
 

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -622,7 +622,6 @@
               "curl -H X-Binaris-Api-Key:* https://*"
     -   in: bn invoke doomedtofailnode8
         err: |-
-            DebugID: *
             some error
             Error: some error
                 at Bolt.exports.handler [as userEntryPoint] (/code/function.js:5:9)
@@ -744,7 +743,7 @@
     -   in: bn create node8 dispensabledrop
     -   in: bn remove dispensabledrop
         err: |-
-            DebugID: *
+            DebugId: *
             Error: No such function
         exit: 1
     -   in: bn deploy dispensabledrop
@@ -752,7 +751,7 @@
         out: "*Removed function dispensabledrop*"
     -   in: bn remove dispensabledrop
         err: |-
-            DebugID: *
+            DebugId: *
             Error: No such function
         exit: 1
     -   in: bn remove

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -622,6 +622,7 @@
               "curl -H X-Binaris-Api-Key:* https://*"
     -   in: bn invoke doomedtofailnode8
         err: |-
+            DebugID: *
             some error
             Error: some error
                 at Bolt.exports.handler [as userEntryPoint] (/code/function.js:5:9)
@@ -742,13 +743,17 @@
   steps:
     -   in: bn create node8 dispensabledrop
     -   in: bn remove dispensabledrop
-        err: "Error: No such function"
+        err: |-
+            DebugID: *
+            Error: No such function
         exit: 1
     -   in: bn deploy dispensabledrop
     -   in: bn remove dispensabledrop
         out: "*Removed function dispensabledrop*"
     -   in: bn remove dispensabledrop
-        err: "Error: No such function"
+        err: |-
+            DebugID: *
+            Error: No such function
         exit: 1
     -   in: bn remove
         err: "*Not enough non-option arguments: got 0, need at least 1"
@@ -864,10 +869,12 @@
     -   in: bn create node8 perplexingpersimmon
     -   in: bn deploy perplexingpersimmon
         err: |-
+            DebugId: *
             Error: Invalid API key
         exit: 1
     -   in: bn list
         err: |-
+            DebugId: *
             Error: Invalid API key
         exit: 1
     -   in: BINARIS_API_KEY=boguskey bn invoke perplexingpersimmon
@@ -999,7 +1006,9 @@
     - dd if=/dev/urandom bs=1048576 count=300 of=very.large.data
   steps:
     - in: bn deploy largeData300MB
-      err: "Error: Payload too large"
+      err: |-
+        DebugId: *
+        Error: Payload too large
       exit: 1
 
 - test: Test deploy of long name (good-path)

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -722,6 +722,7 @@
               "curl -H X-Binaris-Api-Key:* https://*"
     -   in: bn invoke doomedtofailjava8
         err: |-
+            RequestId: *
             <html>
             <head>
             <meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -575,11 +575,10 @@
         exit: 1
     -   in: bn invoke nosuchfunction
         err: |-
+            RequestId: *
             Sorry, your function is not ready yet.
             Please try again.
             If this keeps happening, please contact support@binaris.com with the request ID.
-
-            request_id: *
         exit: 1
 
 - test: Test user code timeout (bad-path)
@@ -597,11 +596,10 @@
     -   in: bn deploy timeoutforsure
     -   in: bn invoke timeoutforsure
         err: |-
+            RequestId: *
             Something went wrong, and it's not your fault.
             If this keeps happening, please contact support@binaris.com with the request ID.
             Apologies.
-
-            request_id: *
         exit: 1
 
 - test: Test bad user node8 code (bad-path)
@@ -878,8 +876,8 @@
         exit: 1
     -   in: BINARIS_API_KEY=boguskey bn invoke perplexingpersimmon
         err: |-
+            RequestId: *
             Unauthorized request. Make sure you're passing the right API key.
-            request_id: *
         exit: 1
 
 - test: Invalid characters in API key when invoking (bad-path)


### PR DESCRIPTION
I expect to get some strong pushback regarding the way I inject the debug ID string into the final output. I initially did so without modifying the `ApiError` constructor but this seemed to be much less DRY. 

Invoke was originally intended to be included with this patch but after doing some digging it appears that `bolt` does not even send a `debugID` with errors. I'm relatively sure this is an oversight but if not I would love to understand the rationale. 

I tested this locally and via the spec tests (although they are meager).