### PR TITLE
Print everything when show has --all

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -327,7 +327,8 @@ Usage: $0 <command> [options]` // eslint-disable-line comma-dangle
         alias: 'a',
         describe: 'Show it all',
         type: 'boolean',
-      });
+      })
+      .strict();
   }, async (argv) => {
     if (!argv.all && !argv.config) {
       msgAndExit('"bn show" requires positional arguments or the "--all" flag', true);

--- a/cli.js
+++ b/cli.js
@@ -316,7 +316,7 @@ Usage: $0 <command> [options]` // eslint-disable-line comma-dangle
     }
     await handleCommand(argv, statsHandler);
   })
-  .command('show <config>', 'Show Binaris account configuration', (yargs0) => {
+  .command('show [config]', 'Show Binaris account configuration', (yargs0) => {
     yargs0
       .positional('config', {
         describe: 'What to show',

--- a/cli.js
+++ b/cli.js
@@ -321,8 +321,18 @@ Usage: $0 <command> [options]` // eslint-disable-line comma-dangle
       .positional('config', {
         describe: 'What to show',
         choices: ['accountId', 'apiKey'],
+      })
+      .option('all', {
+        alias: 'a',
+        describe: 'Show it all ',
+        type: 'boolean',
       });
-  }, argv => handleCommand(argv, showHandler))
+  }, async (argv) => {
+    if (!argv.all && !argv.config) {
+      msgAndExit('"bn show" requires positional arguments or the "--all" flag', true);
+    }
+    await handleCommand(argv, showHandler);
+  })
   .command('login', 'Login to your Binaris account using an API key and account id', (yargs0) => {
     yargs0
       .usage('Usage: $0 login')

--- a/cli.js
+++ b/cli.js
@@ -318,13 +318,14 @@ Usage: $0 <command> [options]` // eslint-disable-line comma-dangle
   })
   .command('show [config]', 'Show Binaris account configuration', (yargs0) => {
     yargs0
+      .usage('Usage: $0 show --all | <config>')
       .positional('config', {
         describe: 'What to show',
         choices: ['accountId', 'apiKey'],
       })
       .option('all', {
         alias: 'a',
-        describe: 'Show it all ',
+        describe: 'Show it all',
         type: 'boolean',
       });
   }, async (argv) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -280,9 +280,9 @@ const statsHandler = async function statsHandler(options) {
 const showHandler = async function showHandler({ config, all }) {
   const conf = await loadAndValidateUserConf();
   if (all) {
-    for (const confKey in conf) {
+    Object.keys(conf).forEach((confKey) => {
       logger.info(`${confKey}: ${conf[confKey]}`);
-    }
+    });
   } else {
     logger.info(conf[config]);
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -278,12 +278,21 @@ const statsHandler = async function statsHandler(options) {
  * Show information about configured account.
  */
 const showHandler = async function showHandler({ config, all }) {
+  const showMap = {};
   if (config === 'accountId' || all) {
-    logger.info(await getAccountId());
+    showMap.accountId = await getAccountId();
   }
   if (config === 'apiKey' || all) {
-    logger.info(await getAPIKey());
+    showMap.apiKey = await getAPIKey();
   }
+
+  Object.keys(showMap).forEach((showKey) => {
+    if (all) {
+      logger.info(`${showKey}: ${showMap[showKey]}`);
+    } else {
+      logger.info(`${showMap[showKey]}`);
+    }
+  });
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -278,6 +278,10 @@ const statsHandler = async function statsHandler(options) {
  * Show information about configured account.
  */
 const showHandler = async function showHandler({ config }) {
+  if (config === undefined) {
+    logger.info(`accountId: ${(await getAccountId())}`);
+    logger.info(`apiKey: ${(await getAPIKey())}`);
+  }
   if (config === 'accountId') logger.info(await getAccountId());
   if (config === 'apiKey') logger.info(await getAPIKey());
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -277,13 +277,13 @@ const statsHandler = async function statsHandler(options) {
 /**
  * Show information about configured account.
  */
-const showHandler = async function showHandler({ config }) {
-  if (config === undefined) {
-    logger.info(`accountId: ${(await getAccountId())}`);
-    logger.info(`apiKey: ${(await getAPIKey())}`);
+const showHandler = async function showHandler({ config, all }) {
+  if (config === 'accountId' || all) {
+    logger.info(await getAccountId());
   }
-  if (config === 'accountId') logger.info(await getAccountId());
-  if (config === 'apiKey') logger.info(await getAPIKey());
+  if (config === 'apiKey' || all) {
+    logger.info(await getAPIKey());
+  }
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ const perf = require('./perf');
 const remove = require('./remove');
 const YMLUtil = require('./binarisYML');
 const {
-  loadAndValidateUserConf,
+  getAllConf,
   getAccountId,
   updateAccountId,
   updateAPIKey,
@@ -278,7 +278,7 @@ const statsHandler = async function statsHandler(options) {
  * Show information about configured account.
  */
 const showHandler = async function showHandler({ config, all }) {
-  const conf = await loadAndValidateUserConf();
+  const conf = await getAllConf();
   if (all) {
     Object.keys(conf).forEach((confKey) => {
       logger.info(`${confKey}: ${conf[confKey]}`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ const perf = require('./perf');
 const remove = require('./remove');
 const YMLUtil = require('./binarisYML');
 const {
-  getAPIKey,
+  loadAndValidateUserConf,
   getAccountId,
   updateAccountId,
   updateAPIKey,
@@ -278,21 +278,14 @@ const statsHandler = async function statsHandler(options) {
  * Show information about configured account.
  */
 const showHandler = async function showHandler({ config, all }) {
-  const showMap = {};
-  if (config === 'accountId' || all) {
-    showMap.accountId = await getAccountId();
-  }
-  if (config === 'apiKey' || all) {
-    showMap.apiKey = await getAPIKey();
-  }
-
-  Object.keys(showMap).forEach((showKey) => {
-    if (all) {
-      logger.info(`${showKey}: ${showMap[showKey]}`);
-    } else {
-      logger.info(`${showMap[showKey]}`);
+  const conf = await loadAndValidateUserConf();
+  if (all) {
+    for (const confKey in conf) {
+      logger.info(`${confKey}: ${conf[confKey]}`);
     }
-  });
+  } else {
+    logger.info(conf[config]);
+  }
 };
 
 /**

--- a/lib/userConf.js
+++ b/lib/userConf.js
@@ -5,25 +5,28 @@ const { homedir } = require('os');
 const path = require('path');
 const yaml = require('js-yaml');
 const partial = require('lodash.partial');
+const bind = require('lodash.bind');
 
 const userConfDirectory = process.env.BINARIS_CONF_DIR || process.env.HOME || homedir();
 const userConfFile = '.binaris.yml';
 const userConfPath = path.join(userConfDirectory, userConfFile);
+
+const confMapping = {
+  apiKey: {
+    env: 'BINARIS_API_KEY',
+    printable: 'API key',
+  },
+  accountId: {
+    env: 'BINARIS_ACCOUNT_ID',
+    printable: 'account ID',
+  },
+};
 
 const loadUserConf = async function loadUserConf() {
   const confString = await fs.readFile(userConfPath, 'utf8');
   const userConf = yaml.safeLoad(confString);
   return userConf;
 };
-
-async function loadAndValidateUserConf() {
-  try {
-    const userConf = await loadUserConf();
-    return userConf;
-  } catch (err) {
-    throw new Error('Binaris conf file could not be read, please use "bn login"');
-  }
-}
 
 const saveUserConf = async function saveUserConf(userConf) {
   const confString = yaml.dump(userConf);
@@ -62,7 +65,7 @@ const getConf = async function getConf(key, envVar, ...defaultValue) {
 
   let userConf;
   try {
-    userConf = await loadAndValidateUserConf();
+    userConf = await loadUserConf();
   } catch (err) {} // eslint-disable-line no-empty
 
   if (!userConf || !Object.prototype.hasOwnProperty.call(userConf, key)) {
@@ -100,13 +103,30 @@ const validateUpdate = function validateUpdate(func, context) {
   return async function update(value) { await func(validateHeaderValue(value, context)); };
 };
 
+const confGetters = Object.keys(confMapping).reduce((aggr, curr) => {
+  const item = confMapping[curr];
+  return {
+    ...aggr,
+    [curr]: validateGet(bind(getConf, {}, curr, item.env), item.printable),
+  };
+}, {});
+
+async function getAllConf() {
+  const allConf = {};
+  for (const getterKey of Object.keys(confGetters)) {
+    // eslint-disable-next-line no-await-in-loop
+    allConf[getterKey] = await confGetters[getterKey]();
+  }
+  return allConf;
+}
+
 module.exports = {
-  loadAndValidateUserConf,
+  getAllConf,
   validateHeaderValue,
   updateAPIKey: validateUpdate(partial(updateConf, 'apiKey'), 'API key'),
-  getAPIKey: validateGet(partial(getConf, 'apiKey', 'BINARIS_API_KEY'), 'API key'),
+  getAPIKey: confGetters.apiKey,
   updateAccountId: validateUpdate(partial(updateConf, 'accountId'), 'account ID'),
-  getAccountId: validateGet(partial(getConf, 'accountId', 'BINARIS_ACCOUNT_ID'), 'account ID'),
+  getAccountId: confGetters.accountId,
   updateRealm: partial(updateConf, 'realm'),
   getRealm: partial(getConf, 'realm', 'realm', ''),
 };

--- a/lib/userConf.js
+++ b/lib/userConf.js
@@ -60,11 +60,17 @@ const getConf = async function getConf(key, envVar, ...defaultValue) {
   const value = process.env[envVar];
   if (value) return value;
 
-  const userConf = await loadAndValidateUserConf();
+  let userConf;
+  try {
+    userConf = await loadAndValidateUserConf();
+  } catch (err) {}
 
   if (!userConf || !Object.prototype.hasOwnProperty.call(userConf, key)) {
     if (defaultValue.length === 1) {
       return defaultValue[0];
+    }
+    if (!userConf) {
+      throw new Error(`Binaris conf file could not be read and ${envVar} is undefined, please use "bn login"`);
     }
     throw new Error(`Invalid Binaris conf file (missing ${key}) ${userConfPath}`);
   }

--- a/lib/userConf.js
+++ b/lib/userConf.js
@@ -63,7 +63,7 @@ const getConf = async function getConf(key, envVar, ...defaultValue) {
   let userConf;
   try {
     userConf = await loadAndValidateUserConf();
-  } catch (err) {}
+  } catch (err) {} // eslint-disable-line no-empty
 
   if (!userConf || !Object.prototype.hasOwnProperty.call(userConf, key)) {
     if (defaultValue.length === 1) {

--- a/lib/userConf.js
+++ b/lib/userConf.js
@@ -21,9 +21,9 @@ async function loadAndValidateUserConf() {
     const userConf = await loadUserConf();
     return userConf;
   } catch (err) {
-    throw new Error(`Binaris conf file could not be read, please use "bn login"`);
+    throw new Error('Binaris conf file could not be read, please use "bn login"');
   }
-};
+}
 
 const saveUserConf = async function saveUserConf(userConf) {
   const confString = yaml.dump(userConf);

--- a/lib/userConf.js
+++ b/lib/userConf.js
@@ -16,6 +16,15 @@ const loadUserConf = async function loadUserConf() {
   return userConf;
 };
 
+async function loadAndValidateUserConf() {
+  try {
+    const userConf = await loadUserConf();
+    return userConf;
+  } catch (err) {
+    throw new Error(`Binaris conf file could not be read, please use "bn login"`);
+  }
+};
+
 const saveUserConf = async function saveUserConf(userConf) {
   const confString = yaml.dump(userConf);
   await fs.writeFile(userConfPath, confString, 'utf8');
@@ -51,18 +60,11 @@ const getConf = async function getConf(key, envVar, ...defaultValue) {
   const value = process.env[envVar];
   if (value) return value;
 
-  let userConf;
-  try {
-    userConf = await loadUserConf();
-  } catch (err) {} // eslint-disable-line no-empty
-  // TODO: only ignore file not found / permission errors
+  const userConf = await loadAndValidateUserConf();
 
   if (!userConf || !Object.prototype.hasOwnProperty.call(userConf, key)) {
     if (defaultValue.length === 1) {
       return defaultValue[0];
-    }
-    if (!userConf) {
-      throw new Error(`Binaris conf file could not be read and ${envVar} is undefined, please use "bn login"`);
     }
     throw new Error(`Invalid Binaris conf file (missing ${key}) ${userConfPath}`);
   }
@@ -93,6 +95,7 @@ const validateUpdate = function validateUpdate(func, context) {
 };
 
 module.exports = {
+  loadAndValidateUserConf,
   validateHeaderValue,
   updateAPIKey: validateUpdate(partial(updateConf, 'apiKey'), 'API key'),
   getAPIKey: validateGet(partial(getConf, 'apiKey', 'BINARIS_API_KEY'), 'API key'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binaris",
-  "version": "6.6.2",
+  "version": "6.6.3",
   "description": "Binaris SDK & CLI",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "inquirer": "^3.3.0",
     "js-yaml": "^3.11.0",
     "loadtest": "^3.0.3",
+    "lodash.bind": "^4.2.1",
     "lodash.get": "^4.4.2",
     "lodash.partial": "^4.2.1",
     "lodash.sortby": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binaris",
-  "version": "6.6.1",
+  "version": "6.6.2",
   "description": "Binaris SDK & CLI",
   "main": "index.js",
   "bin": {

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -15,7 +15,7 @@
                 bn list [options]                         List all deployed functions
                 bn perf <function> [options]              Measure invocation latency (experimental)
                 bn logs <function> [options]              Print the logs of a function
-                bn show <config>                          Show Binaris account configuration
+                bn show [config]                          Show Binaris account configuration
                 bn login                                  Login to your Binaris account using an API key and account id
                 bn feedback <email> <message>             Provide feedback on the Binaris product
 
@@ -131,6 +131,10 @@
       out: "1066"
     - in: BINARIS_API_KEY=17890505 bn show apiKey
       out: "17890505"
+    - in: BINARIS_ACCOUNT_ID=1066 BINARIS_API_KEY=17890505 bn show
+      out: |-
+          accountId: 1066
+          apiKey: 17890505
 
 - test: Test create (good-path)
   steps:

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -139,7 +139,7 @@
             "bn invoke momentousgiants"
             "curl -H X-Binaris-Api-Key:* https://*"
 
-- test: Test show
+- test: Test show (good-path)
   steps:
     - in: BINARIS_ACCOUNT_ID=1066 bn show accountId
       out: "1066"
@@ -149,6 +149,23 @@
       out: |-
           apiKey: 17890505
           accountId: 1066
+
+- test: Test show with unknown option (bad-path)
+  steps:
+    - in: bn show accountId --json
+      err: |-
+          Usage: bn show --all | <config>
+
+          Positionals:
+            config  What to show  [choices: "accountId", "apiKey"]
+
+          Options:
+            --version   Show version number  [boolean]
+            --help, -h  Show help  [boolean]
+            --all, -a   Show it all  [boolean]
+
+          Unknown argument: json
+      exit: 1
 
 - test: Test create (good-path)
   steps:

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -152,8 +152,8 @@
       out: "17890505"
     - in: bn show --all
       out: |-
-          apiKey: 1066
-          accountId: 17890505
+          apiKey: 17890505
+          accountId: 1066
 
 - test: Test create (good-path)
   steps:

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -131,10 +131,10 @@
       out: "1066"
     - in: BINARIS_API_KEY=17890505 bn show apiKey
       out: "17890505"
-    - in: BINARIS_ACCOUNT_ID=1066 BINARIS_API_KEY=17890505 bn show
+    - in: BINARIS_ACCOUNT_ID=1066 BINARIS_API_KEY=17890505 bn show --all
       out: |-
-          accountId: 1066
-          apiKey: 17890505
+          1066
+          17890505
 
 - test: Test create (good-path)
   steps:

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -141,14 +141,19 @@
 
 - test: Test show
   steps:
-    - in: BINARIS_ACCOUNT_ID=1066 bn show accountId
+    -   in: |-
+            cat <<EOF >/home/dockeruser/.binaris.yml
+            apiKey: 17890505
+            accountId: 1066
+            EOF
+    - in: bn show accountId
       out: "1066"
-    - in: BINARIS_API_KEY=17890505 bn show apiKey
+    - in: bn show apiKey
       out: "17890505"
-    - in: BINARIS_ACCOUNT_ID=1066 BINARIS_API_KEY=17890505 bn show --all
+    - in: bn show --all
       out: |-
-          1066
-          17890505
+          apiKey: 1066
+          accountId: 17890505
 
 - test: Test create (good-path)
   steps:

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -37,6 +37,20 @@
                 --help, -h  Show help  [boolean]
                 --json      Output as JSON*
 
+- test: Test show help output
+  steps:
+    -   in: bn show --help
+        out: |-
+              Usage: bn show --all | <config>
+
+              Positionals:
+                config  What to show  [choices: "accountId", "apiKey"]
+
+              Options:
+                --version   Show version number  [boolean]
+                --help, -h  Show help  [boolean]
+                --all, -a   Show it all  [boolean]
+
 - test: Test logs help output (good-path)
   steps:
     -   in: bn logs --help

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -147,8 +147,8 @@
       out: "17890505"
     - in: BINARIS_ACCOUNT_ID=1066 BINARIS_API_KEY=17890505 bn show --all
       out: |-
-          1066
-          17890505
+          apiKey: 17890505
+          accountId: 1066
 
 - test: Test create (good-path)
   steps:

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -141,19 +141,14 @@
 
 - test: Test show
   steps:
-    -   in: |-
-            cat <<EOF >/home/dockeruser/.binaris.yml
-            apiKey: 17890505
-            accountId: 1066
-            EOF
-    - in: bn show accountId
+    - in: BINARIS_ACCOUNT_ID=1066 bn show accountId
       out: "1066"
-    - in: bn show apiKey
+    - in: BINARIS_API_KEY=17890505 bn show apiKey
       out: "17890505"
-    - in: bn show --all
+    - in: BINARIS_ACCOUNT_ID=1066 BINARIS_API_KEY=17890505 bn show --all
       out: |-
-          apiKey: 17890505
-          accountId: 1066
+          1066
+          17890505
 
 - test: Test create (good-path)
   steps:


### PR DESCRIPTION
Fix #443 (as requested by Avner)

This still rejects any args but `apiKey`, `accountId` or empty.