### PR TITLE
Add experimental warning for java8

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -15,6 +15,8 @@ const runtimeToTemplateDir = {
   python3: 'py2',
 };
 
+const experimentalRuntimes = ['java8'];
+
 /**
  * Creates a Binaris function with the given name at the
  * provided path. If a name is not provided one will be randomly
@@ -51,4 +53,7 @@ const create = async function create(functionName, functionPath,
   return finalName;
 };
 
-module.exports = create;
+module.exports = {
+  create,
+  experimentalRuntimes,
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 
 const { inspect } = require('util');
 const deploy = require('./deploy');
-const create = require('./create');
+const { create, experimentalRuntimes } = require('./create');
 const feedback = require('./feedback');
 const invoke = require('./invoke');
 const list = require('./list');
@@ -109,6 +109,9 @@ const createHandler = async function createHandler(options) {
     logger.verbose(`with ${inspect(config)}`);
   }
   logger.info(`  (use "bn deploy${optPath}${optName}" to deploy the function)`);
+  if (experimentalRuntimes.includes(options.runtime)) {
+    logger.warn(`Please be aware, support for ${options.runtime} is currently experimental`);
+  }
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,7 @@ const createHandler = async function createHandler(options) {
   }
   logger.info(`  (use "bn deploy${optPath}${optName}" to deploy the function)`);
   if (experimentalRuntimes.includes(options.runtime)) {
-    logger.warn(`Please be aware, support for ${options.runtime} is currently experimental`);
+    logger.warn(`${options.runtime} support is experimental`);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "binaris",
-  "version": "6.6.3",
+  "version": "6.6.4",
   "description": "Binaris SDK & CLI",
   "main": "index.js",
   "bin": {

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -867,6 +867,7 @@
         out: |-
             Created function * in /home/dockeruser/test
               (use "bn deploy doomedtofailjava8" to deploy the function)
+            Please be aware, support for java8 is currently experimental
     -   in: |-
             sed -i.bak '6s/.*/        throw new java.lang.Error("this is very bad");/' src/main/java/ExampleFunction.java
     -   in: gradle jar

--- a/test/spec.yml
+++ b/test/spec.yml
@@ -867,7 +867,7 @@
         out: |-
             Created function * in /home/dockeruser/test
               (use "bn deploy doomedtofailjava8" to deploy the function)
-            Please be aware, support for java8 is currently experimental
+            java8 support is experimental
     -   in: |-
             sed -i.bak '6s/.*/        throw new java.lang.Error("this is very bad");/' src/main/java/ExampleFunction.java
     -   in: gradle jar


### PR DESCRIPTION
After a short discussion we decided to add a small warning to `bn create` for `java8` mostly driven by the fact that there are no `java8` scoobie tests. 