### PR TITLE
Use ava assert method for power-assert context

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "yargs": "^11.0.0"
   },
   "devDependencies": {
-    "ava": "^1.0.0-rc.1",
+    "ava": "^1.4.0",
     "dockerode": "^2.5.5",
     "eslint": "^3.14.1",
     "eslint-config-airbnb-base": "^11.0.1",

--- a/test/test.js
+++ b/test/test.js
@@ -112,8 +112,8 @@ function createTest(rawSubTest) {
     // eslint-disable-next-line no-param-reassign
     t.context.cleanup = rawSubTest.cleanup;
 
-    const matchText = function matchText(expected, text) {
-      return createRegTest(expected).test(text);
+    const matchText = function matchText(expected, stripCmd, prop) {
+      return createRegTest(expected[prop]).test(stripCmd[`std${prop}`]);
     };
 
     for (const step of rawSubTest.steps) {
@@ -121,11 +121,11 @@ function createTest(rawSubTest) {
       const cmdOut = await t.context.ct.streamIn(step.in);
       if (step.out) {
         const stripCmdOut = { ...cmdOut, stdout: stripText(cmdOut.stdout) };
-        t.assert(matchText(step.out, stripCmdOut.stdout));
+        t.assert(matchText(step, stripCmdOut, 'out'));
       }
       if (step.err) {
         const stripCmdStderr = { ...cmdOut, stderr: stripText(cmdOut.stderr) };
-        t.assert(matchText(step.err, stripCmdStderr.stderr));
+        t.assert(matchText(step, stripCmdStderr, 'err'));
       }
       t.assert(cmdOut.exitCode === (step.exit || 0), cmdOut.stderr);
     }

--- a/test/test.js
+++ b/test/test.js
@@ -120,14 +120,14 @@ function createTest(rawSubTest) {
       // eslint-disable-next-line no-await-in-loop
       const cmdOut = await t.context.ct.streamIn(step.in);
       if (step.out) {
-        const stripStdout = stripText(cmdOut.stdout);
-        t.true(matchText(step.out, stripStdout));
+        const stripCmdOut = { ...cmdOut, stdout: stripText(cmdOut.stdout) };
+        t.assert(matchText(step.out, stripCmdOut.stdout));
       }
       if (step.err) {
-        const stripStderr = stripText(cmdOut.stderr);
-        t.true(matchText(step.err, stripStderr));
+        const stripCmdStderr = { ...cmdOut, stderr: stripText(cmdOut.stderr) };
+        t.assert(matchText(step.err, stripCmdStderr.stderr));
       }
-      t.true(cmdOut.exitCode === (step.exit || 0), step.err);
+      t.assert(cmdOut.exitCode === (step.exit || 0), cmdOut.stderr);
     }
   });
 }


### PR DESCRIPTION
As noticed earlier today context disappeared from assertions due to ava upgrade, this brings the context back.

Second run purposefully broken to see the errors.